### PR TITLE
Fixed undefined stubRequest symbol when header is used in an ObjC++ file

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -17,4 +17,12 @@ typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 - (AndReturnMethod)andReturn;
 @end
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
 LSStubRequestDSL * stubRequest(NSString *method, NSString *url);
+    
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Just a simple fix.
