### PR TITLE
Support for OS X in Nocilla.podspec

### DIFF
--- a/Nocilla.podspec
+++ b/Nocilla.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/luisobo/Nocilla.git", :tag => "0.1" }
 
-   s.platform     = :ios, '4.0'
+  s.ios.deployment_target = '4.0'
+  s.osx.deployment_target = '10.7'
 
   s.source_files = 'Nocilla/**/*.{h,m}'
 


### PR DESCRIPTION
Hi.

Added OS X 10.7 as a deployment target to the podspec to enable Cocopods usage with OS X projects (>=10.7).

Since Nocilla works fine with OS X I think this is useful since Cocopods falsely claims that Nocilla is not compatible with OS X.

Thanks in advance,
Stefan
