### PR TITLE
Add helper methods for HTTP Authentication

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -6,6 +6,7 @@
 
 typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
+typedef LSStubRequestDSL *(^WithAuthorizationHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^AndBodyMethod)(NSString *);
 typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);
@@ -14,6 +15,7 @@ typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData
 - (id)initWithRequest:(LSStubRequest *)request;
 - (WithHeaderMethod)withHeader;
 - (WithHeadersMethod)withHeaders;
+- (WithAuthorizationHeaderMethod)withAuthorization;
 - (AndBodyMethod)withBody;
 - (AndReturnMethod)andReturn;
 - (AndReturnRawResponseMethod)andReturnRawResponse;

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -33,6 +33,13 @@
     };
 }
 
+- (WithAuthorizationHeaderMethod)withAuthorization {
+    return ^(NSString * username, NSString * password) {
+        [self.request setAuthorizationHeaderWithUsername:username password:password];
+        return self;
+    };
+}
+
 - (AndBodyMethod)withBody {
     return ^(NSString *body) {
         self.request.body = [body dataUsingEncoding:NSUTF8StringEncoding];

--- a/Nocilla/Stubs/LSStubRequest.h
+++ b/Nocilla/Stubs/LSStubRequest.h
@@ -15,6 +15,7 @@
 
 - (id)initWithMethod:(NSString *)method url:(NSString *)url;
 - (void)setHeader:(NSString *)header value:(NSString *)value;
+- (void)setAuthorizationHeaderWithUsername:(NSString *)username password:(NSString *)password;
 
 - (BOOL)matchesRequest:(id<LSHTTPRequest>)request;
 @end

--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -1,5 +1,34 @@
 #import "LSStubRequest.h"
 
+static NSString * LSBase64EncodedStringFromString(NSString *string) {
+    NSData *data = [NSData dataWithBytes:[string UTF8String] length:[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
+    NSUInteger length = [data length];
+    NSMutableData *mutableData = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
+
+    uint8_t *input = (uint8_t *)[data bytes];
+    uint8_t *output = (uint8_t *)[mutableData mutableBytes];
+
+    for (NSUInteger i = 0; i < length; i += 3) {
+        NSUInteger value = 0;
+        for (NSUInteger j = i; j < (i + 3); j++) {
+            value <<= 8;
+            if (j < length) {
+                value |= (0xFF & input[j]);
+            }
+        }
+
+        static uint8_t const kAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        NSUInteger idx = (i / 3) * 4;
+        output[idx + 0] = kAFBase64EncodingTable[(value >> 18) & 0x3F];
+        output[idx + 1] = kAFBase64EncodingTable[(value >> 12) & 0x3F];
+        output[idx + 2] = (i + 1) < length ? kAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
+        output[idx + 3] = (i + 2) < length ? kAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
+    }
+
+    return [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
+}
+
 @interface LSStubRequest ()
 @property (nonatomic, assign, readwrite) NSString *method;
 @property (nonatomic, strong, readwrite) NSURL *url;
@@ -24,6 +53,11 @@
 
 - (void)setHeader:(NSString *)header value:(NSString *)value {
     [self.mutableHeaders setValue:value forKey:header];
+}
+
+- (void)setAuthorizationHeaderWithUsername:(NSString *)username password:(NSString *)password {
+	NSString *basicAuthCredentials = [NSString stringWithFormat:@"%@:%@", username, password];
+    [self setHeader:@"Authorization" value:[NSString stringWithFormat:@"Basic %@", LSBase64EncodedStringFromString(basicAuthCredentials)]];
 }
 
 - (NSDictionary *)headers {

--- a/NocillaTests/DSL/LSHTTPRequestDSLRepresentationSpec.m
+++ b/NocillaTests/DSL/LSHTTPRequestDSLRepresentationSpec.m
@@ -48,6 +48,16 @@ describe(@"description", ^{
             [[[dsl description] should] equal:expected];
         });
     });
+    describe(@"a request with authorization", ^{
+        beforeEach(^{
+            LSStubRequest *request = [[LSStubRequest alloc] initWithMethod:@"POST" url:@"http://luissolano.com"];
+            [request setAuthorizationHeaderWithUsername:@"username" password:@"password"];
+            dsl = [[LSHTTPRequestDSLRepresentation alloc] initWithRequest:request];
+        });
+        it(@"should return the DSL representation", ^{
+            [[[dsl description] should] equal:@"stubRequest(@\"POST\", @\"http://luissolano.com\").\nwithHeaders(@{ @\"Authorization\": @\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\" });"];
+        });
+    });
     describe(@"when a header contains a double quoute", ^{
         beforeEach(^{
             LSStubRequest *request = [[LSStubRequest alloc] initWithMethod:@"POST" url:@"http://luissolano.com"];

--- a/NocillaTests/Hooks/NSURLRequest/AFNetworkingStubbingSpec.m
+++ b/NocillaTests/Hooks/NSURLRequest/AFNetworkingStubbingSpec.m
@@ -157,5 +157,33 @@ context(@"AFNetworking", ^{
         [[[operation.response.allHeaderFields objectForKey:@"Content-Type"] shouldEventually] equal:@"text/plain"];
         [operation.error shouldBeNil];
     });
+
+    it(@"should stub a request with authorization", ^{
+        stubRequest(@"POST", @"https://example.com/say-hello").
+        withHeader(@"Content-Type", @"text/plain").
+        withHeader(@"X-MY-AWESOME-HEADER", @"sisisi").
+        withBody(@"Adios!").
+        withAuthorization(@"username", @"password").
+        andReturn(200).
+        withHeader(@"Content-Type", @"text/plain").
+        withBody(@"hola");
+
+        NSURL *url = [NSURL URLWithString:@"https://example.com/say-hello"];
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+        [request setHTTPMethod:@"POST"];
+        [request setValue:@"text/plain" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:@"sisisi" forHTTPHeaderField:@"X-MY-AWESOME-HEADER"];
+        [request setHTTPBody:[@"Adios!" dataUsingEncoding:NSASCIIStringEncoding]];
+        [request setValue:@"Basic dXNlcm5hbWU6cGFzc3dvcmQ=" forHTTPHeaderField:@"Authorization"];
+        AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+        [operation start];
+
+        [operation waitUntilFinished];
+
+        [operation.error shouldBeNil];
+        [[operation.responseString should] equal:@"hola"];
+        [[theValue(operation.response.statusCode) should] equal:theValue(200)];
+        [[[operation.response.allHeaderFields objectForKey:@"Content-Type"] should] equal:@"text/plain"];
+    });
 });
 SPEC_END


### PR DESCRIPTION
While you can currently use something like `withHeader(@"Authorization", @"Basic dGVzdDE6dGVzdDE="). // test1:test1`, I added a small helper to do `withAuthorization(@"username", @"password")` instead
