### PR TITLE
Removes Warning that occurs when building for 64-bit systems

### DIFF
--- a/Nocilla/Stubs/LSStubResponse.m
+++ b/Nocilla/Stubs/LSStubResponse.m
@@ -59,7 +59,7 @@
 
 - (NSString *)description {
     return [NSString stringWithFormat:@"StubRequest:\nStatus Code: %d\nHeaders: %@\nBody: %@",
-            self.statusCode,
+            (int)self.statusCode,
             self.mutableHeaders,
             self.body];
 }


### PR DESCRIPTION
On 64-bit systems NSInteger is of type long, which results in a compiler warning when used in format strings. This pull requests casts the value to an int to get rid of the warning.
