### PR TITLE
Add install instructions for CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,21 @@ This library was inspired by [WebMock](https://github.com/bblimke/webmock) and i
 * At this moment only works with requests made with `NSURLConnection`, but it's possible to extend Nocilla to support more HTTP libraries. Nocilla has been tested with [AFNetworking](https://github.com/AFNetworking/AFNetworking) and [MKNetworkKit](https://github.com/MugunthKumar/MKNetworkKit)
 
 ## Installation
+Installation using [CocoaPod](http://cocoapods.org/).
+
+Create a `Podfile` in your project root directory:
+
+```
+platform :ios, '5.0'
+
+pod 'Nocilla'
+```
+
+Run `pod install` on the command line in your project root directory. To open your project, use `xcworkspace` instead of `xcodeproj`.
+
 Depends on `CFNetwork.framework`. Add it to your target at -> `Build Phases` -> `Link Binary With Libraries`.
 
-_WIP_ (please, read: You figure it out, and then you tell me)
-
-* Nocilla will be a [CocoaPod](http://cocoapods.org/) soon.
-* You should be able to add Nocilla to you source tree. If you are using git, consider using a `git submodule`
+Instead of using CocoaPods, you should also be able to add Nocilla to you source tree. If you are using git, consider using a `git submodule`
 
 ## Usage
 _Yes, the following code is valid Objective-C, or at least, it should be_


### PR DESCRIPTION
Explains how to install Nocilla with CocoaPods.

You also have to add `CFNetwork.framework`, otherwise compilation fails with

```
Undefined symbols for architecture i386: "_CFHTTPMessageAppendBytes", "_CFHTTPMessageCopyAllHeaderFields", "_CFHTTPMessageCopyBody", "_CFHTTPMessageCreateEmpty", "_CFHTTPMessageGetResponseStatusCode", "_CFHTTPMessageIsHeaderComplete"
```
