### PR TITLE
Avoid Ruby 1.9 hash syntax in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@ target :NocillaTests, :exclusive => true do
    pod 'MKNetworkKit', '~> 0.87'
    pod 'AFNetworking', '= 1.0RC1'
    pod 'CocoaHTTPServer', '~> 2.2.1'
-   pod 'Kiwi', git: 'git://github.com/allending/Kiwi.git', commit: 'c4354439fcc70114584212ab0c9d2a3c6523f96c'
+   pod 'Kiwi', :git => 'git://github.com/allending/Kiwi.git', :commit => 'c4354439fcc70114584212ab0c9d2a3c6523f96c'
 end


### PR DESCRIPTION
It seems wise to stick with 1.8 hash syntax until Apple decides to move the system Ruby to 1.9.
