### PR TITLE
Support requests using HTTPBodyStream

### DIFF
--- a/Nocilla.xcodeproj/project.pbxproj
+++ b/Nocilla.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		A0EE630715EC217A00009A08 /* LSHTTPRequestDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EE630515EC217A00009A08 /* LSHTTPRequestDiff.h */; };
 		A0EE630815EC217A00009A08 /* LSHTTPRequestDiff.m in Sources */ = {isa = PBXBuildFile; fileRef = A0EE630615EC217A00009A08 /* LSHTTPRequestDiff.m */; };
 		A0EE631515ECD8B900009A08 /* NSURLRequest+LSHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EE631315ECD8B900009A08 /* NSURLRequest+LSHTTPRequest.h */; };
+		AA0A44061758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0A44051758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +160,7 @@
 		A0EE631315ECD8B900009A08 /* NSURLRequest+LSHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+LSHTTPRequest.h"; path = "Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.h"; sourceTree = "<group>"; };
 		A0EE631415ECD8B900009A08 /* NSURLRequest+LSHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+LSHTTPRequest.m"; path = "Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.m"; sourceTree = "<group>"; };
 		A0EE631715ECDAF300009A08 /* LSHTTPRequestDiffSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSHTTPRequestDiffSpec.m; path = Diff/LSHTTPRequestDiffSpec.m; sourceTree = "<group>"; };
+		AA0A44051758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+LSHTTPRequestSpec.m"; path = "Hooks/NSURLRequest/NSURLRequest+LSHTTPRequestSpec.m"; sourceTree = "<group>"; };
 		CADACB517CAB41DD8263C667 /* libPods-NocillaTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NocillaTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -271,6 +273,7 @@
 				A0708DBC15E70D9800352085 /* MKNetworkKitStubbingSpec.m */,
 				A0055F0115EFFA8B005D6C85 /* NSURLRequestHookSpec.m */,
 				A060B22415FE680900BEAD54 /* LSHTTPStubURLProtocolSpec.m */,
+				AA0A44051758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m */,
 			);
 			name = NSURLRequest;
 			sourceTree = "<group>";
@@ -610,6 +613,7 @@
 				A08EE2291728A3A9001830E6 /* LSStringMatcherSpec.m in Sources */,
 				A02889241728BEFD00288022 /* LSTestRequest.m in Sources */,
 				A02889431728CD6000288022 /* LSRegexMatcherSpec.m in Sources */,
+				AA0A44061758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Nocilla/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.m
+++ b/Nocilla/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.m
@@ -13,7 +13,32 @@
 - (NSDictionary *)headers {
     return self.allHTTPHeaderFields;
 }
+
 - (NSData *)body {
+    if (self.HTTPBodyStream) {
+        NSInputStream *stream = self.HTTPBodyStream;
+        NSMutableData *data = [NSMutableData data];
+        [stream open];
+        size_t bufferSize = 4096;
+        uint8_t *buffer = malloc(bufferSize);
+        if (buffer == NULL) {
+            [NSException raise:@"NocillaMallocFailure" format:@"Could not allocate %zu bytes to read HTTPBodyStream", bufferSize];
+        }
+        while ([stream hasBytesAvailable]) {
+            NSInteger bytesRead = [stream read:buffer maxLength:bufferSize];
+            if (bytesRead > 0) {
+                NSData *readData = [NSData dataWithBytes:buffer length:bytesRead];
+                [data appendData:readData];
+            } else if (bytesRead < 0) {
+                [NSException raise:@"NocillaStreamReadError" format:@"An error occurred while reading HTTPBodyStream (%d)", bytesRead];
+            }
+        }
+        free(buffer);
+        [stream close];
+
+        return data;
+    }
+
     return self.HTTPBody;
 }
 

--- a/NocillaTests/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequestSpec.m
+++ b/NocillaTests/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequestSpec.m
@@ -1,0 +1,25 @@
+#import "Kiwi.h"
+#import "NSURLRequest+LSHTTPRequest.h"
+
+SPEC_BEGIN(NSURLRequest_LSHTTPRequestSpec)
+
+describe(@"-body", ^{
+    __block NSURLRequest *request;
+
+    context(@"when the request provides a body stream", ^{
+        __block NSString *stringUrl = @"http://api.example.com/dogs.xml";
+        __block NSData *requestBody = [@"arg1=foo&arg2=bar" dataUsingEncoding:NSUTF8StringEncoding];
+
+        beforeEach(^{
+            NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:stringUrl]];
+            mutableRequest.HTTPBodyStream = [NSInputStream inputStreamWithData:requestBody];
+            request = mutableRequest;
+        });
+
+        it(@"uses the entire stream as the body", ^{
+            [[[request body] should] equal:requestBody];
+        });
+    });
+});
+
+SPEC_END


### PR DESCRIPTION
NSURLRequest's HTTPBody and HTTPBodyStream are mutually exclusive, so first check if HTTPBodyStream is non-nil and read its entire contents as the request body.
