### PR TITLE
Replace import with forward declaration.

### DIFF
--- a/Nocilla/LSNocilla.h
+++ b/Nocilla/LSNocilla.h
@@ -1,9 +1,9 @@
 #import <Foundation/Foundation.h>
 #import "Nocilla.h"
-#import "LSHTTPRequest.h"
 
 @class LSStubRequest;
 @class LSStubResponse;
+@protocol LSHTTPRequest;
 
 extern NSString * const LSUnexpectedRequest;
 


### PR DESCRIPTION
The import caused build errors when I specified the following in the `Podfile` of a project using Nocilla:

``` ruby
pod 'Nocilla', git: 'https://github.com/luisobo/Nocilla',
               commit: 'afdd8d17b9f701959ff6b27c1d4172fe34d05798'
```
