### PR TITLE
Current podspec is broken.

### DIFF
--- a/Nocilla.podspec
+++ b/Nocilla.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
     'Nocilla/DSL/LSStubRequestDSL.h',
     'Nocilla/DSL/LSStubResponseDSL.h',
     'Nocilla/Matchers/*.h',
+    'Nocilla/Model/LSHTTPBody.h',
     'Nocilla/Categories/NSString+Nocilla.h',
     'Nocilla/Categories/NSData+Nocilla.h']
 


### PR DESCRIPTION
[These](https://github.com/luisobo/Nocilla/blob/0.6/Nocilla/Categories/NSData%2BNocilla.h) [two](https://github.com/luisobo/Nocilla/blob/0.6/Nocilla/Categories/NSString%2BNocilla.h) category interfaces depend on `LSHTTPBody.h`, which is not added to the public headers and thus fails to build the test target that it’s used in.

I have not pushed this to the master spec repo, because it’s up to you how you want this fixed, but please do remember to push the eventual fix to that repo too.
