### PR TITLE
Adding correct redirect handling

### DIFF
--- a/Nocilla.xcodeproj/project.pbxproj
+++ b/Nocilla.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0FA3E7FE1680775B001DB582 /* LSStubResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3E7FD1680775B001DB582 /* LSStubResponseSpec.m */; };
+		3D09BA7EB4C7FBDB2C4B338E /* LSRegexMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D09B626ED742075A763CB1F /* LSRegexMatcherSpec.m */; };
+		3D09BE7874F7D5DDF161EEFA /* LSStringMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D09BB01AB229367DFF49F51 /* LSStringMatcherSpec.m */; };
 		41D450B99F6B46088DB143B3 /* libPods-NocillaTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CADACB517CAB41DD8263C667 /* libPods-NocillaTests.a */; };
 		A0055EE415EEAE08005D6C85 /* MKNetworkKitStubbingSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A0708DBC15E70D9800352085 /* MKNetworkKitStubbingSpec.m */; };
 		A0055EE815EEAF8C005D6C85 /* LSTestingConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A0055EE715EEAF8C005D6C85 /* LSTestingConnection.m */; };
@@ -30,7 +32,6 @@
 		A028893A1728C95600288022 /* NSRegularExpression+Matcheable.m in Sources */ = {isa = PBXBuildFile; fileRef = A02889381728C95600288022 /* NSRegularExpression+Matcheable.m */; };
 		A028893E1728CA5900288022 /* NSString+Nocilla.h in Headers */ = {isa = PBXBuildFile; fileRef = A028893C1728CA5900288022 /* NSString+Nocilla.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A028893F1728CA5900288022 /* NSString+Nocilla.m in Sources */ = {isa = PBXBuildFile; fileRef = A028893D1728CA5900288022 /* NSString+Nocilla.m */; };
-		A02889431728CD6000288022 /* LSRegexMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A02889421728CD6000288022 /* LSRegexMatcherSpec.m */; };
 		A02C7ACA15ECDD780061FCEE /* LSHTTPRequestDiffSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A0EE631715ECDAF300009A08 /* LSHTTPRequestDiffSpec.m */; };
 		A02C7AD215ED702B0061FCEE /* LSStubRequestDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = A02C7AD015ED702B0061FCEE /* LSStubRequestDSL.h */; };
 		A02C7AD315ED702B0061FCEE /* LSStubRequestDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = A02C7AD115ED702B0061FCEE /* LSStubRequestDSL.m */; };
@@ -67,7 +68,6 @@
 		A08D52C815E5A6A7003650F7 /* Nocilla.h in Headers */ = {isa = PBXBuildFile; fileRef = A085B84015E30749007D33C1 /* Nocilla.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A08EE2271728A2F4001830E6 /* LSStringMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A08EE2251728A2F4001830E6 /* LSStringMatcher.h */; };
 		A08EE2281728A2F4001830E6 /* LSStringMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A08EE2261728A2F4001830E6 /* LSStringMatcher.m */; };
-		A08EE2291728A3A9001830E6 /* LSStringMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A08EE2231728A241001830E6 /* LSStringMatcherSpec.m */; };
 		A092C5AC177BBCC400B5C5F9 /* NSData+Nocilla.h in Headers */ = {isa = PBXBuildFile; fileRef = A092C5AA177BBCC400B5C5F9 /* NSData+Nocilla.h */; };
 		A092C5AD177BBCC400B5C5F9 /* NSData+Nocilla.m in Sources */ = {isa = PBXBuildFile; fileRef = A092C5AB177BBCC400B5C5F9 /* NSData+Nocilla.m */; };
 		A0BB870115FE7C2E0090236F /* AFNetworkingStubbingSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A085B85915E30749007D33C1 /* AFNetworkingStubbingSpec.m */; };
@@ -107,6 +107,8 @@
 /* Begin PBXFileReference section */
 		0FA3E7FD1680775B001DB582 /* LSStubResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LSStubResponseSpec.m; sourceTree = "<group>"; };
 		3CB9A3DF4AB94FEA9A99A67B /* Pods-NocillaTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NocillaTests.xcconfig"; path = "Pods/Pods-NocillaTests.xcconfig"; sourceTree = SOURCE_ROOT; };
+		3D09B626ED742075A763CB1F /* LSRegexMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSRegexMatcherSpec.m; path = Matchers/LSRegexMatcherSpec.m; sourceTree = "<group>"; };
+		3D09BB01AB229367DFF49F51 /* LSStringMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSStringMatcherSpec.m; path = Matchers/LSStringMatcherSpec.m; sourceTree = "<group>"; };
 		A0055EE615EEAF8C005D6C85 /* LSTestingConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSTestingConnection.h; path = Support/LSTestingConnection.h; sourceTree = "<group>"; };
 		A0055EE715EEAF8C005D6C85 /* LSTestingConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSTestingConnection.m; path = Support/LSTestingConnection.m; sourceTree = "<group>"; };
 		A0055F0115EFFA8B005D6C85 /* NSURLRequestHookSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSURLRequestHookSpec.m; path = Hooks/NSURLRequest/NSURLRequestHookSpec.m; sourceTree = "<group>"; };
@@ -131,7 +133,6 @@
 		A02889381728C95600288022 /* NSRegularExpression+Matcheable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSRegularExpression+Matcheable.m"; path = "Matchers/NSRegularExpression+Matcheable.m"; sourceTree = "<group>"; };
 		A028893C1728CA5900288022 /* NSString+Nocilla.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+Nocilla.h"; path = "Categories/NSString+Nocilla.h"; sourceTree = "<group>"; };
 		A028893D1728CA5900288022 /* NSString+Nocilla.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+Nocilla.m"; path = "Categories/NSString+Nocilla.m"; sourceTree = "<group>"; };
-		A02889421728CD6000288022 /* LSRegexMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSRegexMatcherSpec.m; path = Matchers/LSRegexMatcherSpec.m; sourceTree = "<group>"; };
 		A02C7AD015ED702B0061FCEE /* LSStubRequestDSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSStubRequestDSL.h; path = DSL/LSStubRequestDSL.h; sourceTree = "<group>"; };
 		A02C7AD115ED702B0061FCEE /* LSStubRequestDSL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSStubRequestDSL.m; path = DSL/LSStubRequestDSL.m; sourceTree = "<group>"; };
 		A02C7AD815ED704F0061FCEE /* LSStubResponseDSL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSStubResponseDSL.h; path = DSL/LSStubResponseDSL.h; sourceTree = "<group>"; };
@@ -166,7 +167,6 @@
 		A085B85415E30749007D33C1 /* NocillaTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "NocillaTests-Info.plist"; sourceTree = "<group>"; };
 		A085B85615E30749007D33C1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A085B85915E30749007D33C1 /* AFNetworkingStubbingSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AFNetworkingStubbingSpec.m; path = Hooks/NSURLRequest/AFNetworkingStubbingSpec.m; sourceTree = "<group>"; };
-		A08EE2231728A241001830E6 /* LSStringMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSStringMatcherSpec.m; path = Matchers/LSStringMatcherSpec.m; sourceTree = "<group>"; };
 		A08EE2251728A2F4001830E6 /* LSStringMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSStringMatcher.h; path = Matchers/LSStringMatcher.h; sourceTree = "<group>"; };
 		A08EE2261728A2F4001830E6 /* LSStringMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSStringMatcher.m; path = Matchers/LSStringMatcher.m; sourceTree = "<group>"; };
 		A092C5A9177BB0A000B5C5F9 /* LSHTTPBody.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LSHTTPBody.h; path = Model/LSHTTPBody.h; sourceTree = "<group>"; };
@@ -211,6 +211,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3D09B31A6B9963CD27754EBD /* Matchers */ = {
+			isa = PBXGroup;
+			children = (
+				3D09BB01AB229367DFF49F51 /* LSStringMatcherSpec.m */,
+				3D09B626ED742075A763CB1F /* LSRegexMatcherSpec.m */,
+			);
+			name = Matchers;
+			sourceTree = "<group>";
+		};
 		A0055EE515EEAF73005D6C85 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -309,6 +318,7 @@
 			children = (
 				A01CEBDC175FFE0300637CE7 /* ASIHTTPRequest */,
 				A02C7B0C15EE65EB0061FCEE /* NSURLRequest */,
+				3D09B31A6B9963CD27754EBD /* Matchers */,
 			);
 			name = Hooks;
 			sourceTree = "<group>";
@@ -421,7 +431,6 @@
 		A085B85215E30749007D33C1 /* NocillaTests */ = {
 			isa = PBXGroup;
 			children = (
-				A08EE2201728A1FC001830E6 /* Matchers */,
 				A0BB870415FE7D7E0090236F /* Stubs */,
 				A0055EE515EEAF73005D6C85 /* Support */,
 				A02C7B0D15EE66250061FCEE /* Diff */,
@@ -458,15 +467,6 @@
 				A02889341728C88D00288022 /* LSRegexMatcher.m */,
 				A02889371728C95600288022 /* NSRegularExpression+Matcheable.h */,
 				A02889381728C95600288022 /* NSRegularExpression+Matcheable.m */,
-			);
-			name = Matchers;
-			sourceTree = "<group>";
-		};
-		A08EE2201728A1FC001830E6 /* Matchers */ = {
-			isa = PBXGroup;
-			children = (
-				A08EE2231728A241001830E6 /* LSStringMatcherSpec.m */,
-				A02889421728CD6000288022 /* LSRegexMatcherSpec.m */,
 			);
 			name = Matchers;
 			sourceTree = "<group>";
@@ -668,12 +668,12 @@
 				A0BB870315FE7C350090236F /* LSHTTPStubURLProtocolSpec.m in Sources */,
 				A0BB870615FE7D8F0090236F /* LSStubRequestSpec.m in Sources */,
 				0FA3E7FE1680775B001DB582 /* LSStubResponseSpec.m in Sources */,
-				A08EE2291728A3A9001830E6 /* LSStringMatcherSpec.m in Sources */,
 				A02889241728BEFD00288022 /* LSTestRequest.m in Sources */,
-				A02889431728CD6000288022 /* LSRegexMatcherSpec.m in Sources */,
 				A01CEBED1760081F00637CE7 /* LSNocillaSpec.m in Sources */,
 				A01CEBDE175FFE3200637CE7 /* ASIHTTPRequestStubbingSpec.m in Sources */,
 				AA0A44061758E27100D2F909 /* NSURLRequest+LSHTTPRequestSpec.m in Sources */,
+				3D09BE7874F7D5DDF161EEFA /* LSStringMatcherSpec.m in Sources */,
+				3D09BA7EB4C7FBDB2C4B338E /* LSRegexMatcherSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -36,10 +36,17 @@
                                                  requestTime:0];
         NSData *body = stubbedResponse.body;
 
-        [client URLProtocol:self didReceiveResponse:urlResponse
-         cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-        [client URLProtocol:self didLoadData:body];
-        [client URLProtocolDidFinishLoading:self];
+        if (stubbedResponse.statusCode < 300 || stubbedResponse.statusCode > 399 ) {
+            [client URLProtocol:self didReceiveResponse:urlResponse
+             cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+            [client URLProtocol:self didLoadData:body];
+            [client URLProtocolDidFinishLoading:self];
+        }
+        else {
+            [client URLProtocol:self
+         wasRedirectedToRequest:stubbedResponse.redirectRequest
+               redirectResponse:urlResponse];
+        }
     }
 }
 

--- a/Nocilla/Stubs/LSStubResponse.h
+++ b/Nocilla/Stubs/LSStubResponse.h
@@ -15,4 +15,6 @@
 - (id)initWithRawResponse:(NSData *)rawResponseData;
 - (id)initDefaultResponse;
 - (void)setHeader:(NSString *)header value:(NSString *)value;
+
+- (NSURLRequest *)redirectRequest;
 @end

--- a/Nocilla/Stubs/LSStubResponse.m
+++ b/Nocilla/Stubs/LSStubResponse.m
@@ -68,8 +68,17 @@
 - (void)setHeader:(NSString *)header value:(NSString *)value {
     [self.mutableHeaders setValue:value forKey:header];
 }
+
 - (NSDictionary *)headers {
     return [NSDictionary dictionaryWithDictionary:self.mutableHeaders];
+}
+
+- (NSURLRequest *)redirectRequest {
+    if ( _statusCode > 299 && _statusCode < 400 && [_mutableHeaders objectForKey:@"Location"] != nil ) {
+        return [NSURLRequest requestWithURL:[NSURL URLWithString:[_mutableHeaders objectForKey:@"Location"]]];
+    }
+
+    return nil;
 }
 
 - (NSString *)description {

--- a/NocillaTests/LSStubResponseSpec.m
+++ b/NocillaTests/LSStubResponseSpec.m
@@ -26,6 +26,16 @@ describe(@"#initWithRawResponse:", ^{
             [[stubResponse.body should] equal:[@"{\"success\":true}" dataUsingEncoding:NSUTF8StringEncoding]];
         });
     });
+
+    context(@"when the responseCode is a 3xx redirect", ^{
+        it(@"should provide an suitable redirect request", ^{
+            LSStubResponse *stubResponse = [[LSStubResponse alloc] initWithStatusCode:301];
+            [stubResponse setHeader:@"Location" value:@"redirect.html"];
+
+            NSURLRequest *redirectRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"redirect.html"]];
+            [[stubResponse.redirectRequest should] equal:redirectRequest];
+        });
+    });
 });
 
 SPEC_END

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
   - Kiwi (2.0.6)
   - MKNetworkKit (0.87):
     - Reachability (~> 3.1.0)
-  - Reachability (3.1.0)
+  - Reachability (3.1.1)
 
 DEPENDENCIES:
   - AFNetworking (= 1.0RC1)
@@ -41,6 +41,6 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 5b2c6e153a8b251dc4b5cea52138e5c2665e2eca
   Kiwi: 56082a80f942de4d10423d8d8a599ab30cf50228
   MKNetworkKit: f174100f92473012138b6b1c3040266af8d43a14
-  Reachability: ba94ecd4eaa037be3d0588b38956672588530c5b
+  Reachability: 2be6bc2fd2bd31d97f5db33e75e4b29c79e95883
 
-COCOAPODS: 0.22.1
+COCOAPODS: 0.22.3


### PR DESCRIPTION
When mocking a 3xx request, the `URLProtocolClient` does not call the `URLProtocol:wasRedirectedToRequest:redirectResponse:` thus intercepting redirects with `connection:willSendRequest:redirectResponse:` (or `setRedirectResponseBlock:` on AFNetworking) does not work.

This pull request contains a simple workaround.
