### PR TITLE
Support Requests with HTTPBodyStream

### DIFF
--- a/Nocilla.xcodeproj/project.pbxproj
+++ b/Nocilla.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0FA3E7FE1680775B001DB582 /* LSStubResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3E7FD1680775B001DB582 /* LSStubResponseSpec.m */; };
-		41D450B99F6B46088DB143B3 /* libPods-NocillaTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CADACB517CAB41DD8263C667 /* libPods-NocillaTests.a */; };
+		5B41631392BA47B7B7494C73 /* libPods-NocillaTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CADACB517CAB41DD8263C667 /* libPods-NocillaTests.a */; };
 		A0055EE415EEAE08005D6C85 /* MKNetworkKitStubbingSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A0708DBC15E70D9800352085 /* MKNetworkKitStubbingSpec.m */; };
 		A0055EE815EEAF8C005D6C85 /* LSTestingConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A0055EE715EEAF8C005D6C85 /* LSTestingConnection.m */; };
 		A01CEBDE175FFE3200637CE7 /* ASIHTTPRequestStubbingSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = A01CEBDD175FFE3200637CE7 /* ASIHTTPRequestStubbingSpec.m */; };
@@ -204,7 +204,7 @@
 				A085B84B15E30749007D33C1 /* SenTestingKit.framework in Frameworks */,
 				A085B84E15E30749007D33C1 /* Foundation.framework in Frameworks */,
 				A085B85115E30749007D33C1 /* libNocilla.a in Frameworks */,
-				41D450B99F6B46088DB143B3 /* libPods-NocillaTests.a in Frameworks */,
+				5B41631392BA47B7B7494C73 /* libPods-NocillaTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -541,6 +541,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A085B86015E30749007D33C1 /* Build configuration list for PBXNativeTarget "NocillaTests" */;
 			buildPhases = (
+				9D4C7BC8F2DF4EA496967380 /* Check Pods Manifest.lock */,
 				A085B84415E30749007D33C1 /* Sources */,
 				A085B84515E30749007D33C1 /* Frameworks */,
 				A085B84615E30749007D33C1 /* Resources */,
@@ -596,6 +597,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		9D4C7BC8F2DF4EA496967380 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		A085B84715E30749007D33C1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -622,6 +638,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Pods-NocillaTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Nocilla/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.m
+++ b/Nocilla/Hooks/NSURLRequest/NSURLRequest+LSHTTPRequest.m
@@ -31,6 +31,8 @@
                 [data appendData:readData];
             } else if (bytesRead < 0) {
                 [NSException raise:@"NocillaStreamReadError" format:@"An error occurred while reading HTTPBodyStream (%d)", bytesRead];
+            } else if (bytesRead == 0) {
+                break;
             }
         }
         free(buffer);

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
-platform :ios
+platform :ios, '5.1'
 
 target :NocillaTests, :exclusive => true do
    pod 'MKNetworkKit', '~> 0.87'
-   pod 'AFNetworking', '= 1.0RC1'
+   pod 'AFNetworking', '~> 1.3.1'
    pod 'CocoaHTTPServer', '~> 2.2.1'
    pod 'Kiwi', :git => 'git://github.com/allending/Kiwi.git', :commit => 'c4354439fcc70114584212ab0c9d2a3c6523f96c'
    pod 'ASIHTTPRequest', '>= 1.8.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AFNetworking (1.0RC1)
+  - AFNetworking (1.3.2)
   - ASIHTTPRequest (1.8.1):
     - ASIHTTPRequest/ASIWebPageRequest
     - ASIHTTPRequest/CloudFiles
@@ -19,10 +19,10 @@ PODS:
   - Kiwi (2.0.6)
   - MKNetworkKit (0.87):
     - Reachability (~> 3.1.0)
-  - Reachability (3.1.0)
+  - Reachability (3.1.1)
 
 DEPENDENCIES:
-  - AFNetworking (= 1.0RC1)
+  - AFNetworking (~> 1.3.1)
   - ASIHTTPRequest (>= 1.8.1)
   - CocoaHTTPServer (~> 2.2.1)
   - Kiwi (from `git://github.com/allending/Kiwi.git`, commit `c4354439fcc70114584212ab0c9d2a3c6523f96c`)
@@ -34,13 +34,13 @@ EXTERNAL SOURCES:
     :git: git://github.com/allending/Kiwi.git
 
 SPEC CHECKSUMS:
-  AFNetworking: b21c1252d437fd322e7db1caa93b163d76a362cb
+  AFNetworking: 7f9bcd7c287a75476cd5c61e82fd3380e93e4c54
   ASIHTTPRequest: a411b8d0f006ed8fc24248be6a0c4ad2abc9b101
   CocoaAsyncSocket: 73c96a4225998adad0c94142010f65e5d12077de
   CocoaHTTPServer: 188251009cdf2fb9f422e6979621b8942733cb22
   CocoaLumberjack: 5b2c6e153a8b251dc4b5cea52138e5c2665e2eca
   Kiwi: 56082a80f942de4d10423d8d8a599ab30cf50228
   MKNetworkKit: f174100f92473012138b6b1c3040266af8d43a14
-  Reachability: ba94ecd4eaa037be3d0588b38956672588530c5b
+  Reachability: 2be6bc2fd2bd31d97f5db33e75e4b29c79e95883
 
-COCOAPODS: 0.22.1
+COCOAPODS: 0.22.3


### PR DESCRIPTION
There's an issue when Nocilla is trying to work with requests those have HTTPBodyStream  
The main problem is that Nocilla doesn't handling case, when NSInputStream (HTTPBodyStream) returns 0 on read: method.  
https://developer.apple.com/library/ios/documentation/cocoa/reference/foundation/Classes/NSInputStream_Class/Reference/Reference.html#//apple_ref/occ/instm/NSInputStream/read:maxLength:  
Documentation says that if stream returns 0, it means that buffer endeded and there's no more bytes to read  
"0 indicates that the end of the buffer was reached;"

So this pull request contains fix for described case
