### PR TITLE
Match request body using block

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -11,6 +11,7 @@
 
 typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
+typedef LSStubRequestDSL *(^AndBodyWhereMethod)(BOOL(^)(NSData *));
 typedef LSStubRequestDSL *(^AndBodyMethod)(id<LSHTTPBody>);
 typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);

--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -22,6 +22,7 @@ typedef void (^AndFailWithErrorMethod)(NSError *error);
 - (WithHeaderMethod)withHeader;
 - (WithHeadersMethod)withHeaders;
 - (AndBodyMethod)withBody;
+- (AndBodyWhereMethod)withBodyWhere;
 - (AndReturnMethod)andReturn;
 - (AndReturnRawResponseMethod)andReturnRawResponse;
 - (AndFailWithErrorMethod)andFailWithError;

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -33,6 +33,13 @@
     };
 }
 
+- (AndBodyWhereMethod)withBodyWhere {
+    return ^(BOOL(^matchesBody)(NSData *)) {
+        self.request.matchesBody = matchesBody;
+        return self;
+    };
+}
+
 - (AndBodyMethod)withBody {
     return ^(id<LSHTTPBody> body) {
         [self.request setBody:[body data]];

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -35,7 +35,7 @@
 
 - (AndBodyMethod)withBody {
     return ^(id<LSHTTPBody> body) {
-        self.request.body = [body data];
+        [self.request setBody:[body data]];
         return self;
     };
 }

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -42,7 +42,7 @@
 
 - (AndBodyMethod)withBody {
     return ^(id<LSHTTPBody> body) {
-        [self.request setBody:[body data]];
+        self.request.body = [body data];
         return self;
     };
 }

--- a/Nocilla/Stubs/LSStubRequest.h
+++ b/Nocilla/Stubs/LSStubRequest.h
@@ -11,7 +11,7 @@
 @property (nonatomic, assign, readonly) NSString *method;
 @property (nonatomic, strong, readonly) LSMatcher *urlMatcher;
 @property (nonatomic, strong, readonly) NSDictionary *headers;
-@property (nonatomic, strong, readwrite) NSData *body;
+@property (nonatomic, copy, readwrite) BOOL(^matchesBody)(NSData *);
 
 @property (nonatomic, strong) LSStubResponse *response;
 
@@ -19,6 +19,7 @@
 - (instancetype)initWithMethod:(NSString *)method urlMatcher:(LSMatcher *)urlMatcher;
 
 - (void)setHeader:(NSString *)header value:(NSString *)value;
+- (void)setBody:(NSData *)body;
 
 - (BOOL)matchesRequest:(id<LSHTTPRequest>)request;
 @end

--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -47,7 +47,7 @@
             self.method,
             self.urlMatcher,
             self.headers,
-            self.matchesBody ? @"(matches block)" : @"(any)",
+            self.matchesBody ? @"(matched by block)" : @"(any)",
             self.response];
 }
 

--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -10,7 +10,6 @@
 -(BOOL)matchesMethod:(id<LSHTTPRequest>)request;
 -(BOOL)matchesURL:(id<LSHTTPRequest>)request;
 -(BOOL)matchesHeaders:(id<LSHTTPRequest>)request;
--(BOOL)matchesBody:(id<LSHTTPRequest>)request;
 @end
 
 @implementation LSStubRequest
@@ -33,6 +32,12 @@
     [self.mutableHeaders setValue:value forKey:header];
 }
 
+- (void)setBody:(NSData *)body {
+    self.matchesBody = ^BOOL(NSData *data) {
+        return [data isEqual:body];
+    };
+}
+
 - (NSDictionary *)headers {
     return [NSDictionary dictionaryWithDictionary:self.mutableHeaders];;
 }
@@ -42,7 +47,7 @@
             self.method,
             self.urlMatcher,
             self.headers,
-            self.body,
+            self.matchesBody ? @"(matches block)" : @"(any)",
             self.response];
 }
 
@@ -86,12 +91,7 @@
 }
 
 -(BOOL)matchesBody:(id<LSHTTPRequest>)request {
-    NSData *selfBody = self.body;
-    NSData *reqBody = request.body;
-    if (!selfBody || [selfBody isEqualToData:reqBody]) {
-        return YES;
-    }
-    return NO;
+    return !self.matchesBody || self.matchesBody(request.body);
 }
 @end
 

--- a/NocillaTests/Stubs/LSStubRequestSpec.m
+++ b/NocillaTests/Stubs/LSStubRequestSpec.m
@@ -184,6 +184,39 @@ describe(@"#matchesRequest:", ^{
             });
         });
     });
+    
+    context(@"when the stubRequest has a matchesBody block", ^{
+        __block LSStubRequest *stubRequest = nil;
+        __block LSTestRequest *actualRequest = nil;
+        beforeEach(^{
+            stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];
+            actualRequest = [[LSTestRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];
+            
+            [stubRequest setHeader:@"Content-Type" value:@"application/json"];
+            [stubRequest setHeader:@"X-API-TOKEN" value:@"123abc"];
+            
+            [actualRequest setHeader:@"Content-Type" value:@"application/json"];
+            [actualRequest setHeader:@"X-API-TOKEN" value:@"123abc"];
+            
+            [stubRequest setMatchesBody:^BOOL(NSData *body) {
+                NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+                return [[bodyString lowercaseString] isEqualToString:@"hola"];
+            }];
+            
+            [actualRequest setBody:[@"Adios, this is a body as well" dataUsingEncoding:NSUTF8StringEncoding]];
+        });
+        describe(@"the stubRequest request", ^{
+            it(@"should match a request for which the block returns YES", ^{
+                [actualRequest setBody:[@"Hola" dataUsingEncoding:NSUTF8StringEncoding]];
+                [[theValue([stubRequest matchesRequest:actualRequest]) should] beYes];
+            });
+            
+            it(@"should not match a request for which the block returns NO", ^{
+                [actualRequest setBody:[@"Adios" dataUsingEncoding:NSUTF8StringEncoding]];
+                [[theValue([stubRequest matchesRequest:actualRequest]) should] beNo];
+            });
+        });
+    });
 });
 
 SPEC_END

--- a/NocillaTests/Stubs/LSStubRequestSpec.m
+++ b/NocillaTests/Stubs/LSStubRequestSpec.m
@@ -157,7 +157,7 @@ describe(@"#matchesRequest:", ^{
             [stubRequest setBody:[@"Hola, this is a body" dataUsingEncoding:NSUTF8StringEncoding]];
             [actualRequest setBody:[@"Adios, this is a body as well" dataUsingEncoding:NSUTF8StringEncoding]];
         });
-        it(@"should match", ^{
+        it(@"should not match", ^{
             [[theValue([stubRequest matchesRequest:actualRequest]) should] beNo];
         });
     });


### PR DESCRIPTION
Request bodies are most often encoded as `application/json`, `application/x-www-form-urlencoded`, or `application/xml`. Each of those encodings can represent the same data in more than one way. 

For example, in JSON encoding, `{"a":1, "b":2}` is equivalent to `{"b":2, "a":1}`. In fact, some JSON serializers behave nondeterministically as to which of those two they emit.

Therefore, it usually doesn't make sense to test the body of a request using `-[NSData equals]`. Instead, you want to use a notion of equality appropriate to the encoding.

This pull enables matching a request body using an arbitrary block, like so:

    stubRequest(@"POST", @"https://api.example.com/endpoint.json").
    withHeaders(@{@"Accept": @"application/json"}).
    withBodyWhere(^(NSData *body){
        id bodyJSONObject = [NSJSONSerialization JSONObjectWithData:body
                                                            options:0
                                                              error:NULL];
        return [bodyJSONObject isEqual:@{@"a": @1, @"b": @2}];
    });