### PR TITLE
add an unstubRequest method, so you can unstub a specific stubbed request

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -31,6 +31,7 @@ extern "C" {
 #endif
     
 LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url);
+void unstubRequest(LSStubRequestDSL *dsl);
     
 #ifdef __cplusplus
 }

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -70,3 +70,7 @@ LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url) {
     [[LSNocilla sharedInstance] addStubbedRequest:request];
     return dsl;
 }
+
+void unstubRequest(LSStubRequestDSL *dsl) {
+    [[LSNocilla sharedInstance] removeStubbedRequest:dsl.request];
+}

--- a/Nocilla/LSNocilla.h
+++ b/Nocilla/LSNocilla.h
@@ -15,6 +15,7 @@ extern NSString * const LSUnexpectedRequest;
 - (void)start;
 - (void)stop;
 - (void)addStubbedRequest:(LSStubRequest *)request;
+- (void)removeStubbedRequest:(LSStubRequest *)request;
 - (void)clearStubs;
 
 - (void)registerHook:(LSHTTPClientHook *)hook;

--- a/Nocilla/LSNocilla.m
+++ b/Nocilla/LSNocilla.m
@@ -58,6 +58,10 @@ static LSNocilla *sharedInstace = nil;
     [self.mutableRequests addObject:request];
 }
 
+- (void)removeStubbedRequest:(LSStubRequest *)request {
+    [self.mutableRequests removeObject:request];
+}
+
 - (void)clearStubs {
     [self.mutableRequests removeAllObjects];
 }

--- a/NocillaTests/LSNocillaSpec.m
+++ b/NocillaTests/LSNocillaSpec.m
@@ -5,6 +5,10 @@
 
 SPEC_BEGIN(LSNocillaSpec)
 
+beforeEach(^{
+    [[LSNocilla sharedInstance] clearStubs];
+});
+
 describe(@"-responseForRequest:", ^{
     context(@"when the specified request matches a previously stubbed request", ^{
         it(@"returns the associated response", ^{
@@ -20,8 +24,6 @@ describe(@"-responseForRequest:", ^{
             LSStubResponse *result = [[LSNocilla sharedInstance] responseForRequest:actualRequest];
 
             [[result should] equal:stubbedResponse];
-
-            [[LSNocilla sharedInstance] clearStubs];
         });
     });
 
@@ -31,15 +33,47 @@ describe(@"-responseForRequest:", ^{
             [actualRequest stub:@selector(url) andReturn:[NSURL URLWithString:@"http://www.google.com"]];
             [actualRequest stub:@selector(method) andReturn:@"GET"];
 
-
             NSString *expectedMessage = @"An unexpected HTTP request was fired.\n\nUse this snippet to stub the request:\nstubRequest(@\"GET\", @\"http://www.google.com\");\n";
             [[theBlock(^{
                 [[LSNocilla sharedInstance] responseForRequest:actualRequest];
             }) should] raiseWithName:@"NocillaUnexpectedRequest" reason:expectedMessage];
-
-            [[LSNocilla sharedInstance] clearStubs];
         });
     });
 });
+
+describe(@"-addStubbedRequest:", ^{
+    it(@"adds the request to the stubbed requests", ^{
+        LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];
+        [[LSNocilla sharedInstance] addStubbedRequest:stubRequest];
+        [[[[LSNocilla sharedInstance] stubbedRequests] should] contain:stubRequest];
+    });
+});
+
+describe(@"-removeStubbedRequest:", ^{
+    it(@"remove any requests which match the given stubbed request", ^{
+        LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];
+        [[LSNocilla sharedInstance] addStubbedRequest:stubRequest];
+        [[[[LSNocilla sharedInstance] stubbedRequests] should] contain:stubRequest];
+
+        [[LSNocilla sharedInstance] removeStubbedRequest:stubRequest];
+
+        [[[[LSNocilla sharedInstance] stubbedRequests] should] beEmpty];
+    });
+});
+
+describe(@"-clearStubs", ^{
+    it(@"remove all requests from the stubbed requests", ^{
+        LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];
+        LSStubRequest *otherRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/tails.json"];
+        [[LSNocilla sharedInstance] addStubbedRequest:stubRequest];
+        [[LSNocilla sharedInstance] addStubbedRequest:otherRequest];
+        [[[[LSNocilla sharedInstance] stubbedRequests] should] containObjects:stubRequest, otherRequest, nil];
+
+        [[LSNocilla sharedInstance] clearStubs];
+
+        [[[[LSNocilla sharedInstance] stubbedRequests] should] beEmpty];
+    });
+});
+
 
 SPEC_END


### PR DESCRIPTION
When you are building out a set of tests, you will undoubtedly build a stack of tests (within describes, contexts, etc.) that can be a few levels deep. If you are down a few levels, and you need to modify a specific url stub to behave differently (to test a different context, perhaps), the only real way to do this is to:

1) Refactor your tests such that the stubbing you wish to change is done further up. This can work, but other times is not ideal as it can result in before blocks that are duplicated across scenarios.
2) Clear all stubs, and re-initialize everything again. Definitely not ideal.

This changeset adds a simple "unstubRequest" method to the DSL and implementation. To use it, one can just store the resulting DSL from a specific stub as a variable, and then later on pass it to unstubRequest to remove it. 

I considered trying to build unstub so that it takes a method and a URL, but that presents complexity/ambiguity when considering whether it will also need you to pass the body/headers, or if it should just remove them all liberally by method/URL alone, or be super conservative and only do exact matches, etc.

Taking the DSL object itself and (only) removing that is probably the simplest approach, and should do the trick for most folks who are looking to just unstub one of many stubs set up for a complex scenario.
