### PR TITLE
README: Fix invalid escape sequence in string

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ stubRequest(@"GET", @"http://www.google.com");
 
 #### Stubbing requests with regular expressions
 ```objc
-stubRequest(@"GET", @"^http://(.*?)\.example\.com/v1/dogs\.json".regex);
+stubRequest(@"GET", @"^http://(.*?)\\.example\\.com/v1/dogs\\.json".regex);
 ```
 
 


### PR DESCRIPTION
The README contains an example of converting a string literal to a
regex, but the string literal contains an invalid escape sequence: "\."

Of course, this is a legal regex pattern, but in order to silence the
warning, use "\\." instead. The pattern matches as it does without the
extra escape.

---

The following displays a warning ("invalid escape sequence"):

``` objc
@"^http://(.*?)\.crunchtime-labs\.com/v1/estimates\.csv".regex
```

Whereas this does not:

``` objc
@"^http://(.*?)\\.crunchtime-labs\\.com/v1/estimates\\.csv".regex
```

Both match the same patterns. That is, either one will match against `http://api.crunchtime-labs.com/v1/estimates.csv`.

Based on the README I first assumed that it was a Nocilla issue, but in fact the regex in the README just needs a little updating.
