### PR TITLE
Added methods to verify that a request was called a certain number of times

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -11,6 +11,7 @@
 
 typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
+typedef LSStubRequestDSL *(^WithCallCountMethod)(NSInteger times);
 typedef LSStubRequestDSL *(^AndBodyMethod)(id<LSHTTPBody>);
 typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);
@@ -20,6 +21,7 @@ typedef void (^AndFailWithErrorMethod)(NSError *error);
 - (id)initWithRequest:(LSStubRequest *)request;
 - (WithHeaderMethod)withHeader;
 - (WithHeadersMethod)withHeaders;
+- (WithCallCountMethod)withCallCount;
 - (AndBodyMethod)withBody;
 - (AndReturnMethod)andReturn;
 - (AndReturnRawResponseMethod)andReturnRawResponse;

--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -33,7 +33,8 @@ extern "C" {
 #endif
     
 LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url);
-    
+LSStubRequestDSL * expectRequest(NSString *method, id<LSMatcheable> url, NSInteger expectedCallCount);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -11,7 +11,7 @@
 
 typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
-typedef LSStubRequestDSL *(^WithCallCountMethod)(NSInteger times);
+typedef LSStubRequestDSL *(^WithExpectedCallCountMethod)(NSInteger times);
 typedef LSStubRequestDSL *(^AndBodyMethod)(id<LSHTTPBody>);
 typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);
@@ -21,7 +21,7 @@ typedef void (^AndFailWithErrorMethod)(NSError *error);
 - (id)initWithRequest:(LSStubRequest *)request;
 - (WithHeaderMethod)withHeader;
 - (WithHeadersMethod)withHeaders;
-- (WithCallCountMethod)withCallCount;
+- (WithExpectedCallCountMethod)withExpectedCallCount;
 - (AndBodyMethod)withBody;
 - (AndReturnMethod)andReturn;
 - (AndReturnRawResponseMethod)andReturnRawResponse;

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -33,6 +33,13 @@
     };
 }
 
+- (WithCallCountMethod)withCallCount {
+	return ^(NSInteger times) {
+		[self.request setExpectedCallCount:@(times)];
+		return self;
+	};
+}
+
 - (AndBodyMethod)withBody {
     return ^(id<LSHTTPBody> body) {
         self.request.body = [body data];

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -33,7 +33,7 @@
     };
 }
 
-- (WithCallCountMethod)withCallCount {
+- (WithExpectedCallCountMethod)withExpectedCallCount {
 	return ^(NSInteger times) {
 		[self.request setExpectedCallCount:@(times)];
 		return self;

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -77,3 +77,7 @@ LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url) {
     [[LSNocilla sharedInstance] addStubbedRequest:request];
     return dsl;
 }
+
+LSStubRequestDSL * expectRequest(NSString *method, id<LSMatcheable> url, NSInteger expectedCallCount) {
+    return stubRequest(method, url).withExpectedCallCount(expectedCallCount);
+}

--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -25,6 +25,7 @@
     NSURLRequest* request = [self request];
 	id<NSURLProtocolClient> client = [self client];
 
+	[[LSNocilla sharedInstance] countRequest:request];
     LSStubResponse* stubbedResponse = [[LSNocilla sharedInstance] responseForRequest:request];
 
     if (stubbedResponse.shouldFail) {

--- a/Nocilla/LSNocilla.h
+++ b/Nocilla/LSNocilla.h
@@ -16,8 +16,10 @@ extern NSString * const LSUnexpectedRequest;
 - (void)stop;
 - (void)addStubbedRequest:(LSStubRequest *)request;
 - (void)clearStubs;
+- (void)verifyCallCount;
 
 - (void)registerHook:(LSHTTPClientHook *)hook;
 
 - (LSStubResponse *)responseForRequest:(id<LSHTTPRequest>)request;
+- (void)countRequest:(id<LSHTTPRequest>)request;
 @end

--- a/Nocilla/LSNocilla.m
+++ b/Nocilla/LSNocilla.m
@@ -13,8 +13,6 @@ NSString * const LSUnexpectedRequest = @"Unexpected Request";
 @property (nonatomic, strong) NSMutableArray *hooks;
 @property (nonatomic, assign, getter = isStarted) BOOL started;
 
-@property (nonatomic) BOOL testmode;
-
 - (void)loadHooks;
 - (void)unloadHooks;
 @end
@@ -79,20 +77,11 @@ static LSNocilla *sharedInstace = nil;
 			NSInteger actualCount = someStubbedRequest.actualCallCount;
 			NSInteger expectedCount = someStubbedRequest.expectedCallCount.integerValue;
 
-			// the exceptions need to be fired on an other thread than the main thread
-			// cause otherwise they might be caught by other frameworks and won't get logged!
 			if (actualCount < expectedCount) {
 				NSString *msg = [NSString stringWithFormat:@"The request to \"%@\" should be fired %d times but was fired %d times.\n",
 								someStubbedRequest.urlMatcher.description, expectedCount, actualCount];
 				NSException *exception = [NSException exceptionWithName:@"NocillaMissingRequest" reason:msg userInfo:nil];
-
-				// we need to raise the exception on the main thread when testing
-				// otherwise the tests will crash cause we cannot catch and assert the exception...
-				if (self.testmode) {
-					[exception raise];
-				} else {
-					[exception performSelectorInBackground:@selector(raise) withObject:nil];
-				}
+				[exception raise];
 			}
 
 		}

--- a/Nocilla/Matchers/LSRegexMatcher.m
+++ b/Nocilla/Matchers/LSRegexMatcher.m
@@ -18,4 +18,8 @@
     return [self.regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)] > 0;
 }
 
+- (NSString *)description {
+	return self.regex.pattern;
+}
+
 @end

--- a/Nocilla/Matchers/LSStringMatcher.m
+++ b/Nocilla/Matchers/LSStringMatcher.m
@@ -20,4 +20,8 @@
     return [self.string isEqualToString:string];
 }
 
+- (NSString *)description {
+	return self.string.description;
+}
+
 @end

--- a/Nocilla/Stubs/LSStubRequest.h
+++ b/Nocilla/Stubs/LSStubRequest.h
@@ -12,6 +12,8 @@
 @property (nonatomic, strong, readonly) LSMatcher *urlMatcher;
 @property (nonatomic, strong, readonly) NSDictionary *headers;
 @property (nonatomic, strong, readwrite) NSData *body;
+@property (nonatomic, strong) NSNumber *expectedCallCount;
+@property (nonatomic) NSInteger actualCallCount;
 
 @property (nonatomic, strong) LSStubResponse *response;
 

--- a/NocillaTests/Hooks/NSURLRequest/LSHTTPStubURLProtocolSpec.m
+++ b/NocillaTests/Hooks/NSURLRequest/LSHTTPStubURLProtocolSpec.m
@@ -90,6 +90,18 @@ describe(@"#startLoading", ^{
             protocol = [[LSHTTPStubURLProtocol alloc] initWithRequest:request cachedResponse:nil client:client]; 
         });
         context(@"that matches an stubbed request", ^{
+			it(@"should increment the requests call count", ^{
+				LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"GET" url:stringUrl];
+				[[LSNocilla sharedInstance] stub:@selector(stubbedRequests) andReturn:@[stubRequest]];
+				[[theValue(stubRequest.actualCallCount) should] equal:theValue(0)];
+
+				[protocol startLoading];
+				[[theValue(stubRequest.actualCallCount) should] equal:theValue(1)];
+
+				[protocol startLoading];
+				[[theValue(stubRequest.actualCallCount) should] equal:theValue(2)];
+			});
+
             context(@"and the response should succeed", ^{
                 beforeEach(^{
                     LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"GET" url:stringUrl];

--- a/NocillaTests/LSNocillaSpec.m
+++ b/NocillaTests/LSNocillaSpec.m
@@ -3,6 +3,11 @@
 #import "LSStubRequest.h"
 #import "LSStubResponse.h"
 
+@interface LSNocilla ()
+@property (nonatomic) BOOL testmode;
+@end
+
+
 SPEC_BEGIN(LSNocillaSpec)
 
 describe(@"-responseForRequest:", ^{
@@ -47,9 +52,11 @@ describe(@"-responseForRequest:", ^{
 			actualRequest = [KWMock nullMockForProtocol:@protocol(LSHTTPRequest)];
 			[actualRequest stub:@selector(url) andReturn:[NSURL URLWithString:@"http://www.google.com"]];
 			[actualRequest stub:@selector(method) andReturn:@"GET"];
+			[[LSNocilla sharedInstance] setTestmode:YES];
 		});
 
 		afterEach(^{
+			[[LSNocilla sharedInstance] setTestmode:NO];
 			[[LSNocilla sharedInstance] clearStubs];
 		});
 

--- a/NocillaTests/LSNocillaSpec.m
+++ b/NocillaTests/LSNocillaSpec.m
@@ -4,11 +4,6 @@
 #import "LSStubResponse.h"
 #import "LSRegexMatcher.h"
 
-@interface LSNocilla ()
-@property (nonatomic) BOOL testmode;
-@end
-
-
 SPEC_BEGIN(LSNocillaSpec)
 
 describe(@"-responseForRequest:", ^{
@@ -75,11 +70,9 @@ describe(@"-responseForRequest:", ^{
 			actualRequest = [KWMock nullMockForProtocol:@protocol(LSHTTPRequest)];
 			[actualRequest stub:@selector(url) andReturn:[NSURL URLWithString:@"http://www.google.com"]];
 			[actualRequest stub:@selector(method) andReturn:@"GET"];
-			[[LSNocilla sharedInstance] setTestmode:YES];
 		});
 
 		afterEach(^{
-			[[LSNocilla sharedInstance] setTestmode:NO];
 			[[LSNocilla sharedInstance] clearStubs];
 		});
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ withBody(@"{\"name\":\"foo\"}").
 andFailWithError([NSError errorWithDomain:@"foo" code:123 userInfo:nil]);
 ```
 
+### Expecting requests
+To verify that a certain request was fired 1 time:
+
+```objc
+stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(1)
+...
+// execute the code that should fire the request
+...
+[[LSNocilla sharedInstance] verifyCallCount];
+
+```
+
+Of course you can combine this with any .withHeaders(), withBody() or andReturn() statements.
+
+
 ### Unexpected requests
 If some request is made but it wasn't stubbed, Nocilla won't let that request hit the real world. In that case your test should fail.
 At this moment Nocilla will raise an exception with a meaningful message about the error and how to solve it, including a snippet of code on how to stub the unexpected request.

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ andFailWithError([NSError errorWithDomain:@"foo" code:123 userInfo:nil]);
 ```
 
 ### Expecting requests
-To verify that a certain request was fired 1 time:
+To verify that a certain request was fired exactly once:
 
 ```objc
-stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(1)
+stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(1);
 ...
 // execute the code that should fire the request
 ...
@@ -177,7 +177,7 @@ stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(
 
 ```
 
-Of course you can combine this with any .withHeaders(), withBody() or andReturn() statements.
+Of course you can combine this with any withHeaders(), withBody() or andReturn() statements.
 
 
 ### Unexpected requests

--- a/README.md
+++ b/README.md
@@ -169,12 +169,23 @@ andFailWithError([NSError errorWithDomain:@"foo" code:123 userInfo:nil]);
 To verify that a certain request was fired exactly once:
 
 ```objc
-stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(1);
+expectRequest(@"GET", @"https://api.example.com/dogs.json", 1);
 ...
 // execute the code that should fire the request
 ...
 [[LSNocilla sharedInstance] verifyCallCount];
 
+```
+
+Instead of:
+
+```objc
+expectRequest(@"GET", @"https://api.example.com/dogs.json", 1);
+```
+
+you can also use:
+```objc
+stubRequest(@"GET", @"https://api.example.com/dogs.json").withExpectedCallCount(1);
 ```
 
 Of course you can combine this with any withHeaders(), withBody() or andReturn() statements.


### PR DESCRIPTION
I added two DSL methods and the corresponding implementation to also verify that stubbed requests were actually sent.
Of course it's an optional feature. For more detail please check out the modified Readme file.
