### PR TITLE
Update LSNSURLSessionHook.m

### DIFF
--- a/Nocilla/Hooks/NSURLSession/LSNSURLSessionHook.m
+++ b/Nocilla/Hooks/NSURLSession/LSNSURLSessionHook.m
@@ -13,11 +13,13 @@
 @implementation LSNSURLSessionHook
 
 - (void)load {
-    [self swizzleSelector:@selector(protocolClasses) fromClass:NSClassFromString(@"__NSCFURLSessionConfiguration") ?: [NSURLSessionConfiguration class] toClass:[self class]];
+    Class cls = NSClassFromString(@"__NSCFURLSessionConfiguration") ?: NSClassFromString(@"NSURLSessionConfiguration");
+    [self swizzleSelector:@selector(protocolClasses) fromClass:cls toClass:[self class]];
 }
 
 - (void)unload {
-    [self swizzleSelector:@selector(protocolClasses) fromClass:NSClassFromString(@"__NSCFURLSessionConfiguration") ?: [NSURLSessionConfiguration class] toClass:[self class]];
+    Class cls = NSClassFromString(@"__NSCFURLSessionConfiguration") ?: NSClassFromString(@"NSURLSessionConfiguration");
+    [self swizzleSelector:@selector(protocolClasses) fromClass:cls toClass:[self class]];
 }
 
 - (void)swizzleSelector:(SEL)selector fromClass:(Class)original toClass:(Class)stub {


### PR DESCRIPTION
In the current implementation, the presence of [NSURLSessionConfiguration class] in the ternary appeared to cause the class to be loaded - even though it isn't returned - and that was causing side effects in iOS7.  Replacing that with NSClassFromString worked.  I also split that long line up.
