### PR TITLE
Status codes 304 and 305 are not redirects.

### DIFF
--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -35,7 +35,8 @@
                                                 headerFields:stubbedResponse.headers
                                                  requestTime:0];
 
-        if (stubbedResponse.statusCode < 300 || stubbedResponse.statusCode > 399) {
+        if (stubbedResponse.statusCode < 300 || stubbedResponse.statusCode > 399
+            || stubbedResponse.statusCode == 304 || stubbedResponse.statusCode == 305 ) {
             NSData *body = stubbedResponse.body;
 
             [client URLProtocol:self didReceiveResponse:urlResponse


### PR DESCRIPTION
In LSHTTPStubURLProtocol, it will treat HTTP status code from 300 to 399 as URL redirection; however, status code 304 (not modified) and 305 (use proxy) are not redirects. refer: http://en.wikipedia.org/wiki/URL_redirection.
