### PR TITLE
Raising an exception in the NSURLSession background thread seemed to pre...

### DIFF
--- a/Nocilla/LSNocilla.m
+++ b/Nocilla/LSNocilla.m
@@ -76,7 +76,11 @@ static LSNocilla *sharedInstace = nil;
             return someStubbedRequest.response;
         }
     }
-    [NSException raise:@"NocillaUnexpectedRequest" format:@"An unexpected HTTP request was fired.\n\nUse this snippet to stub the request:\n%@\n", [[[LSHTTPRequestDSLRepresentation alloc] initWithRequest:actualRequest] description]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        [NSException raise:@"NocillaUnexpectedRequest" format:@"An unexpected HTTP request was fired.\n\nUse this snippet to stub the request:\n%@\n", [[[LSHTTPRequestDSLRepresentation alloc] initWithRequest:actualRequest] description]];
+
+    });
 
     return nil;
 }


### PR DESCRIPTION
...vent

any further requests being made, without terminating the app (I guess the
NSURLSession code is swallowing the exception and dying?).

This quick workaround forces the exception to be raised on the main thread.