### PR TITLE
Change buildable name from octest -> xctest

### DIFF
--- a/Nocilla.xcodeproj/project.pbxproj
+++ b/Nocilla.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		A085B83B15E30749007D33C1 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A085B83F15E30749007D33C1 /* Nocilla-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Nocilla-Prefix.pch"; sourceTree = "<group>"; };
 		A085B84015E30749007D33C1 /* Nocilla.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Nocilla.h; sourceTree = "<group>"; };
-		A085B84915E30749007D33C1 /* NocillaTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = NocillaTests.octest; path = NocillaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A085B84915E30749007D33C1 /* NocillaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NocillaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A085B85415E30749007D33C1 /* NocillaTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "NocillaTests-Info.plist"; sourceTree = "<group>"; };
 		A085B85615E30749007D33C1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A085B85915E30749007D33C1 /* AFNetworkingStubbingSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AFNetworkingStubbingSpec.m; path = Hooks/NSURLRequest/AFNetworkingStubbingSpec.m; sourceTree = "<group>"; };
@@ -405,7 +405,7 @@
 			isa = PBXGroup;
 			children = (
 				A085B83815E30749007D33C1 /* libNocilla.a */,
-				A085B84915E30749007D33C1 /* NocillaTests.octest */,
+				A085B84915E30749007D33C1 /* NocillaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -600,7 +600,7 @@
 			);
 			name = NocillaTests;
 			productName = NocillaTests;
-			productReference = A085B84915E30749007D33C1 /* NocillaTests.octest */;
+			productReference = A085B84915E30749007D33C1 /* NocillaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */

--- a/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla.xcscheme
+++ b/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A085B84815E30749007D33C1"
-               BuildableName = "NocillaTests.octest"
+               BuildableName = "NocillaTests.xctest"
                BlueprintName = "NocillaTests"
                ReferencedContainer = "container:Nocilla.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A085B84815E30749007D33C1"
-               BuildableName = "NocillaTests.octest"
+               BuildableName = "NocillaTests.xctest"
                BlueprintName = "NocillaTests"
                ReferencedContainer = "container:Nocilla.xcodeproj">
             </BuildableReference>
@@ -63,6 +63,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A085B83715E30749007D33C1"
+            BuildableName = "libNocilla.a"
+            BlueprintName = "Nocilla"
+            ReferencedContainer = "container:Nocilla.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"


### PR DESCRIPTION
This change happens automatically by Xcode when changing branches, when in a project using xctest that has Nocilla as a submodule.

Committing this stops us from having dirty changes in the Nocilla submodule every time we change branches in our git repository.