### PR TITLE
Added ability to stub request with a redirect without needing to specify a `Location` header.

### DIFF
--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -4,6 +4,8 @@
 #import "LSStubRequest.h"
 #import "NSURLRequest+DSL.h"
 
+NSString * const kHTTPResponseHeaderLocationKey = @"Location";
+
 @interface NSHTTPURLResponse(UndocumentedInitializer)
 - (id)initWithURL:(NSURL*)URL statusCode:(NSInteger)statusCode headerFields:(NSDictionary*)headerFields requestTime:(double)requestTime;
 @end
@@ -34,9 +36,10 @@
                                                   statusCode:stubbedResponse.statusCode
                                                 headerFields:stubbedResponse.headers
                                                  requestTime:0];
-
+        
         if (stubbedResponse.statusCode < 300 || stubbedResponse.statusCode > 399
-            || stubbedResponse.statusCode == 304 || stubbedResponse.statusCode == 305 ) {
+            || stubbedResponse.statusCode == 304 || stubbedResponse.statusCode == 305
+            || ![stubbedResponse.headers.allKeys containsObject:kHTTPResponseHeaderLocationKey]) {
             NSData *body = stubbedResponse.body;
 
             [client URLProtocol:self didReceiveResponse:urlResponse
@@ -48,7 +51,7 @@
                       [cookieStorage setCookies:[NSHTTPCookie cookiesWithResponseHeaderFields:stubbedResponse.headers forURL:request.url]
                                      forURL:request.URL mainDocumentURL:request.URL];
 
-            NSURL *newURL = [NSURL URLWithString:[stubbedResponse.headers objectForKey:@"Location"] relativeToURL:request.URL];
+            NSURL *newURL = [NSURL URLWithString:[stubbedResponse.headers objectForKey:kHTTPResponseHeaderLocationKey] relativeToURL:request.URL];
             NSMutableURLRequest *redirectRequest = [NSMutableURLRequest requestWithURL:newURL];
 
             [redirectRequest setAllHTTPHeaderFields:[NSHTTPCookie requestHeaderFieldsWithCookies:[cookieStorage cookiesForURL:newURL]]];

--- a/NocillaTests/Hooks/NSURLRequest/LSHTTPStubURLProtocolSpec.m
+++ b/NocillaTests/Hooks/NSURLRequest/LSHTTPStubURLProtocolSpec.m
@@ -152,6 +152,25 @@ describe(@"#startLoading", ^{
                 }) should] raiseWithName:@"NocillaUnexpectedRequest" reason:expectedMessage];
             });
         });
+        
+        context(@"that returns a 303 without specifying a Location header", ^{
+            
+            beforeEach(^{
+                
+                LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"GET" url:stringUrl];
+                stubRequest.response = [[LSStubResponse alloc] initWithStatusCode:(NSInteger)303];
+                
+                [[LSNocilla sharedInstance] stub:@selector(stubbedRequests) andReturn:@[stubRequest]];
+                
+                [protocol startLoading];
+            });
+            
+            it(@"should send back a response with 303", ^{
+                
+                [[client.response should] beKindOfClass:[NSHTTPURLResponse class]];
+                [[theValue(((NSHTTPURLResponse *)client.response).statusCode) should] equal:theValue((NSInteger)303)];
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Referring to this issue: https://github.com/luisobo/Nocilla/issues/120

This will prevent the crash and also provides quicker stubbing for testing if a user doesn't actually need the response to redirect to a new URL.