### PR TITLE
Allow identical stubs to be replaced so that their response can be altered.

### DIFF
--- a/Nocilla/LSNocilla.m
+++ b/Nocilla/LSNocilla.m
@@ -61,7 +61,14 @@ static LSNocilla *sharedInstace = nil;
 }
 
 - (void)addStubbedRequest:(LSStubRequest *)request {
-    [self.mutableRequests addObject:request];
+    NSUInteger index = [self.mutableRequests indexOfObject:request];
+
+    if (index == NSNotFound) {
+        [self.mutableRequests addObject:request];
+        return;
+    }
+
+    [self.mutableRequests replaceObjectAtIndex:index withObject:request];
 }
 
 - (void)clearStubs {

--- a/Nocilla/Matchers/LSDataMatcher.m
+++ b/Nocilla/Matchers/LSDataMatcher.m
@@ -29,4 +29,23 @@
     return [self.data isEqualToData:data];
 }
 
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[LSDataMatcher class]]) {
+        return NO;
+    }
+
+    return [self.data isEqual:((LSDataMatcher *)object).data];
+}
+
+- (NSUInteger)hash {
+    return self.data.hash;
+}
+
 @end

--- a/Nocilla/Matchers/LSMatcher.m
+++ b/Nocilla/Matchers/LSMatcher.m
@@ -10,4 +10,15 @@
     return [self matches:[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
 }
 
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"[LSMatcher isEqual:] is an abstract method" userInfo:nil];
+}
+
+- (NSUInteger)hash {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"[LSMatcher hash] an abstract method" userInfo:nil];
+}
+
 @end

--- a/Nocilla/Matchers/LSRegexMatcher.m
+++ b/Nocilla/Matchers/LSRegexMatcher.m
@@ -18,4 +18,23 @@
     return [self.regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)] > 0;
 }
 
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[LSRegexMatcher class]]) {
+        return NO;
+    }
+
+    return [self.regex isEqual:((LSRegexMatcher *)object).regex];
+}
+
+- (NSUInteger)hash {
+    return self.regex.hash;
+}
+
 @end

--- a/Nocilla/Matchers/LSStringMatcher.m
+++ b/Nocilla/Matchers/LSStringMatcher.m
@@ -20,4 +20,23 @@
     return [self.string isEqualToString:string];
 }
 
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[LSStringMatcher class]]) {
+        return NO;
+    }
+
+    return [self.string isEqualToString:((LSStringMatcher *)object).string];
+}
+
+- (NSUInteger)hash {
+    return self.string.hash;
+}
+
 @end

--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -92,6 +92,39 @@
     }
     return NO;
 }
+
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[LSStubRequest class]]) {
+        return NO;
+    }
+
+    return [self isEqualToStubRequest:object];
+}
+
+- (BOOL)isEqualToStubRequest:(LSStubRequest *)stubRequest {
+    if (!stubRequest) {
+        return NO;
+    }
+
+    BOOL methodEqual = [self.method isEqualToString:stubRequest.method];
+    BOOL urlMatcherEqual = [self.urlMatcher isEqual:stubRequest.urlMatcher];
+    BOOL headersEqual = [self.headers isEqual:stubRequest.headers];
+    BOOL bodyEqual = (self.body == nil && stubRequest.body == nil) || [self.body isEqual:stubRequest.body];
+
+    return methodEqual && urlMatcherEqual && headersEqual && bodyEqual;
+}
+
+- (NSUInteger)hash {
+    return self.method.hash ^ self.urlMatcher.hash ^ self.headers.hash ^ self.body.hash;
+}
+
 @end
 
 

--- a/NocillaTests/LSNocillaSpec.m
+++ b/NocillaTests/LSNocillaSpec.m
@@ -23,6 +23,31 @@ describe(@"-responseForRequest:", ^{
 
             [[LSNocilla sharedInstance] clearStubs];
         });
+
+        describe(@"when a stubbed request is replaced with a new stub", ^{
+            it(@"returns the response for the newer stub", ^{
+                LSStubRequest *firstStub = [[LSStubRequest alloc] initWithMethod:@"GET" url:@"http://www.google.com"];
+                LSStubResponse *firstResponse = [[LSStubResponse alloc] initWithStatusCode:403];
+                firstStub.response = firstResponse;
+                [[LSNocilla sharedInstance] addStubbedRequest:firstStub];
+
+                LSStubRequest *secondStub = [[LSStubRequest alloc] initWithMethod:@"GET" url:@"http://www.google.com"];
+                LSStubResponse *secondResponse = [[LSStubResponse alloc] initWithStatusCode:200];
+                secondStub.response = secondResponse;
+                [[LSNocilla sharedInstance] addStubbedRequest:secondStub];
+
+                NSObject<LSHTTPRequest> *actualRequest = [KWMock nullMockForProtocol:@protocol(LSHTTPRequest)];
+                [actualRequest stub:@selector(url) andReturn:[NSURL URLWithString:@"http://www.google.com"]];
+                [actualRequest stub:@selector(method) andReturn:@"GET"];
+
+                LSStubResponse *result = [[LSNocilla sharedInstance] responseForRequest:actualRequest];
+
+                [[result shouldNot] equal:firstResponse];
+                [[result should] equal:secondResponse];
+
+                [[LSNocilla sharedInstance] clearStubs];
+            });
+        });
     });
 
     context(@"when the specified request does not match any stubbed request", ^{

--- a/NocillaTests/Matchers/LSDataMatcherSpec.m
+++ b/NocillaTests/Matchers/LSDataMatcherSpec.m
@@ -27,4 +27,20 @@ context(@"when both data are different", ^{
     });
 });
 
+describe(@"isEqual:", ^{
+    it(@"is equal to another data matcher with the same data", ^{
+        LSDataMatcher *matcherA = [[LSDataMatcher alloc] initWithData:[@"same" dataUsingEncoding:NSUTF8StringEncoding]];
+        LSDataMatcher *matcherB = [[LSDataMatcher alloc] initWithData:[@"same" dataUsingEncoding:NSUTF8StringEncoding]];
+
+        [[matcherA should] equal:matcherB];
+    });
+
+    it(@"is not equal to another data matcher with a different data", ^{
+        LSDataMatcher *matcherA = [[LSDataMatcher alloc] initWithData:[@"omg" dataUsingEncoding:NSUTF8StringEncoding]];
+        LSDataMatcher *matcherB = [[LSDataMatcher alloc] initWithData:[@"different" dataUsingEncoding:NSUTF8StringEncoding]];
+
+        [[matcherA shouldNot] equal:matcherB];
+    });
+});
+
 SPEC_END

--- a/NocillaTests/Matchers/LSRegexMatcherSpec.m
+++ b/NocillaTests/Matchers/LSRegexMatcherSpec.m
@@ -25,4 +25,20 @@ context(@"when string does not match", ^{
     });
 });
 
+describe(@"isEqual:", ^{
+    it(@"is equal to another regex matcher with the same regex", ^{
+        LSRegexMatcher *matcherA = [[LSRegexMatcher alloc] initWithRegex:@"([same]+)".regex];
+        LSRegexMatcher *matcherB = [[LSRegexMatcher alloc] initWithRegex:@"([same]+)".regex];
+
+        [[matcherA should] equal:matcherB];
+    });
+
+    it(@"is not equal to another regex matcher with a different regex", ^{
+        LSRegexMatcher *matcherA = [[LSRegexMatcher alloc] initWithRegex:@"([omg]+)".regex];
+        LSRegexMatcher *matcherB = [[LSRegexMatcher alloc] initWithRegex:@"([different]+)".regex];
+
+        [[matcherA shouldNot] equal:matcherB];
+    });
+});
+
 SPEC_END

--- a/NocillaTests/Matchers/LSStringMatcherSpec.m
+++ b/NocillaTests/Matchers/LSStringMatcherSpec.m
@@ -20,4 +20,20 @@ context(@"when both strings are different", ^{
     });
 });
 
+describe(@"isEqual:", ^{
+    it(@"is equal to another string matcher with the same string", ^{
+        LSStringMatcher *matcherA = [[LSStringMatcher alloc] initWithString:@"same"];
+        LSStringMatcher *matcherB = [[LSStringMatcher alloc] initWithString:@"same"];
+
+        [[matcherA should] equal:matcherB];
+    });
+
+    it(@"is not equal to another string matcher with a different string", ^{
+        LSStringMatcher *matcherA = [[LSStringMatcher alloc] initWithString:@"omg"];
+        LSStringMatcher *matcherB = [[LSStringMatcher alloc] initWithString:@"different"];
+
+        [[matcherA shouldNot] equal:matcherB];
+    });
+});
+
 SPEC_END

--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ withBody(@"{\"name\":\"foo\"}").
 andFailWithError([NSError errorWithDomain:@"foo" code:123 userInfo:nil]);
 ```
 
+#### Replacing a request stub
+
+If you need to change the response of a single request, simply re-stub the request:
+
+```objc
+stubRequest(@"POST", @"https://api.example.com/authorize/").
+andReturn(401);
+
+// Some test expectation...
+
+stubRequest(@"POST", @"https://api.example.com/authorize/").
+andReturn(200);
+```
+
 ### Unexpected requests
 If some request is made but it wasn't stubbed, Nocilla won't let that request hit the real world. In that case your test should fail.
 At this moment Nocilla will raise an exception with a meaningful message about the error and how to solve it, including a snippet of code on how to stub the unexpected request.


### PR DESCRIPTION
This is handy in the case where the response of a single request needs to be altered.

For example, consider this scenario:

    stubRequest(@"POST", @"https://example.com/authorize/").
    andReturn(401);

    ... some expectation of the 401 ...

    stubRequest(@"POST", @"https://example.com/authorize/").
    andReturn(200);

Previously the only way to achieve this was to call `[LSNocilla clearStubs]` and re-add all stubs.