### PR TITLE
added special handling of Cookie: header

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -11,6 +11,8 @@
 
 typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
 typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
+typedef LSStubRequestDSL *(^WithCookieMethod)(NSString *, NSString *);
+typedef LSStubRequestDSL *(^WithCookiesMethod)(NSDictionary *);
 typedef LSStubRequestDSL *(^AndBodyMethod)(id<LSMatcheable>);
 typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
 typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);
@@ -21,6 +23,8 @@ typedef void (^AndFailWithErrorMethod)(NSError *error);
 
 @property (nonatomic, strong, readonly) WithHeaderMethod withHeader;
 @property (nonatomic, strong, readonly) WithHeadersMethod withHeaders;
+@property (nonatomic, strong, readonly) WithCookieMethod withCookie;
+@property (nonatomic, strong, readonly) WithCookiesMethod withCookies;
 @property (nonatomic, strong, readonly) AndBodyMethod withBody;
 @property (nonatomic, strong, readonly) AndReturnMethod andReturn;
 @property (nonatomic, strong, readonly) AndReturnRawResponseMethod andReturnRawResponse;

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -33,6 +33,23 @@
     };
 }
 
+- (WithCookiesMethod)withCookies {
+	return ^(NSDictionary *cookies) {
+		for (NSString *cookieName in cookies) {
+			NSString *value = [cookies objectForKey:cookieName];
+			[self.request setCookie:cookieName value:value];
+		}
+		return self;
+	};
+}
+
+- (WithCookieMethod)withCookie {
+	return ^(NSString * cookieName, NSString * value) {
+		[self.request setCookie:cookieName value:value];
+		return self;
+	};
+}
+
 - (AndBodyMethod)withBody {
     return ^(id<LSMatcheable> body) {
         self.request.body = body.matcher;

--- a/Nocilla/Model/LSHTTPRequest.h
+++ b/Nocilla/Model/LSHTTPRequest.h
@@ -5,6 +5,7 @@
 @property (nonatomic, strong, readonly) NSURL *url;
 @property (nonatomic, strong, readonly) NSString *method;
 @property (nonatomic, strong, readonly) NSDictionary *headers;
+@property (nonatomic, strong, readonly) NSDictionary *cookies;
 @property (nonatomic, strong, readonly) NSData *body;
 
 @end

--- a/Nocilla/Stubs/LSStubRequest.h
+++ b/Nocilla/Stubs/LSStubRequest.h
@@ -11,6 +11,7 @@
 @property (nonatomic, strong, readonly) NSString *method;
 @property (nonatomic, strong, readonly) LSMatcher *urlMatcher;
 @property (nonatomic, strong, readonly) NSDictionary *headers;
+@property (nonatomic, strong, readonly) NSDictionary *cookies;
 @property (nonatomic, strong, readwrite) LSMatcher *body;
 
 @property (nonatomic, strong) LSStubResponse *response;
@@ -19,6 +20,7 @@
 - (instancetype)initWithMethod:(NSString *)method urlMatcher:(LSMatcher *)urlMatcher;
 
 - (void)setHeader:(NSString *)header value:(NSString *)value;
+- (void)setCookie:(NSString *)cookieName value:(NSString *)value;
 
 - (BOOL)matchesRequest:(id<LSHTTPRequest>)request;
 @end


### PR DESCRIPTION
between iOS 8 and iOS 9, the order of the serialized Cookie changed, as a result, previously passing tests are failing.