### PR TITLE
Add link to recording tool SWHttpTrafficRecorder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ withBody([@"bar" dataUsingEncoding:NSUTF8StringEncoding]);
 #### Returning raw responses recorded with `curl -is`
 `curl -is http://api.example.com/dogs.json > /tmp/example_curl_-is_output.txt`
 
+Or through tools such as [SWHttpTrafficRecorder](https://github.com/capitalone/SWHttpTrafficRecorder) which would recorded all raw responses used by an app while the app is accessed.
+
 ```objc
 stubRequest(@"GET", @"https://api.example.com/dogs.json").
 andReturnRawResponse([NSData dataWithContentsOfFile:@"/tmp/example_curl_-is_output.txt"]);


### PR DESCRIPTION
@luisobo To help users better, do you mind updating the README to include a link to [SWHttpTrafficRecorder](https://github.com/capitalone/SWHttpTrafficRecorder)? This library can record all the raw HTTP(s) responses while a user is using an app, relieving users from the manual process of `curl -is` for each of the HTTP(s) request/response. Thanks a lot in advance and please let me know if it needs to be rephrased or put it some other place instead.