### PR TITLE
LSStubResponse fails to reflect added headers

### DIFF
--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -31,6 +31,7 @@
 
 - (void)setHeader:(NSString *)header value:(NSString *)value {
     [self.mutableHeaders setValue:value forKey:header];
+    [self.response setHeader:header value:value];
 }
 
 - (NSDictionary *)headers {


### PR DESCRIPTION
A request response does not contain the added headers resulting in an error in cases where we expect a certain file type as our response data.