### PR TITLE
Remove non-public API usage

### DIFF
--- a/Nocilla.podspec
+++ b/Nocilla.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "Nocilla"
-  s.version      = "0.10.0"
+  s.version      = "0.11.0"
   s.summary      = "Stunning HTTP stubbing for iOS. Testing HTTP requests has never been easier."
   s.homepage     = "https://github.com/luisobo/Nocilla"
 
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Luis Solano" => "contact@luissolano.com" }
 
-  s.source       = { :git => "https://github.com/luisobo/Nocilla.git", :tag => "0.10.0" }
+  s.source       = { :git => "https://github.com/luisobo/Nocilla.git", :tag => "0.11.0" }
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'

--- a/Nocilla.podspec
+++ b/Nocilla.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/luisobo/Nocilla.git", :tag => "0.10.0" }
 
-  s.ios.deployment_target = '4.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.tvos.deployment_target = '9.0'
 

--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -4,10 +4,6 @@
 #import "LSStubRequest.h"
 #import "NSURLRequest+DSL.h"
 
-@interface NSHTTPURLResponse(UndocumentedInitializer)
-- (id)initWithURL:(NSURL*)URL statusCode:(NSInteger)statusCode headerFields:(NSDictionary*)headerFields requestTime:(double)requestTime;
-@end
-
 @implementation LSHTTPStubURLProtocol
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {
@@ -35,9 +31,9 @@
         [client URLProtocol:self didFailWithError:stubbedResponse.error];
     } else {
         NSHTTPURLResponse* urlResponse = [[NSHTTPURLResponse alloc] initWithURL:request.URL
-                                                  statusCode:stubbedResponse.statusCode
-                                                headerFields:stubbedResponse.headers
-                                                 requestTime:0];
+                                                                     statusCode:stubbedResponse.statusCode
+                                                                    HTTPVersion:nil
+                                                                   headerFields:stubbedResponse.headers];
 
         if (stubbedResponse.statusCode < 300 || stubbedResponse.statusCode > 399
             || stubbedResponse.statusCode == 304 || stubbedResponse.statusCode == 305 ) {


### PR DESCRIPTION
I received this automated validation issue from Apple due to the usage of a non-public API:

> Non-public API usage:
> 
> The app references non-public selectors in Frameworks/Nocilla.framework/Nocilla: initWithURL:statusCode:headerFields:requestTime:, postBody

To fix this, I have replaced the private API with a public API.

The cost of doing this is that iOS 4 is no longer supported.