### PR TITLE
Nullability annotations

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -9,31 +9,31 @@
 
 @protocol LSHTTPBody;
 
-typedef LSStubRequestDSL *(^WithHeaderMethod)(NSString *, NSString *);
-typedef LSStubRequestDSL *(^WithHeadersMethod)(NSDictionary *);
-typedef LSStubRequestDSL *(^AndBodyMethod)(id<LSMatcheable>);
-typedef LSStubResponseDSL *(^AndReturnMethod)(NSInteger);
-typedef LSStubResponseDSL *(^AndReturnRawResponseMethod)(NSData *rawResponseData);
-typedef void (^AndFailWithErrorMethod)(NSError *error);
+typedef LSStubRequestDSL * _Nonnull (^WithHeaderMethod)(NSString * _Nonnull, NSString * _Nullable);
+typedef LSStubRequestDSL * _Nonnull (^WithHeadersMethod)(NSDictionary * _Nullable);
+typedef LSStubRequestDSL * _Nonnull (^AndBodyMethod)(_Nullable id<LSMatcheable>);
+typedef LSStubResponseDSL * _Nonnull (^AndReturnMethod)(NSInteger);
+typedef LSStubResponseDSL * _Nonnull (^AndReturnRawResponseMethod)(NSData * _Nonnull rawResponseData);
+typedef void (^AndFailWithErrorMethod)(NSError * _Nonnull error);
 
 @interface LSStubRequestDSL : NSObject
-- (id)initWithRequest:(LSStubRequest *)request;
+- (id _Nonnull)initWithRequest:(LSStubRequest * _Nonnull)request;
 
-@property (nonatomic, strong, readonly) WithHeaderMethod withHeader;
-@property (nonatomic, strong, readonly) WithHeadersMethod withHeaders;
-@property (nonatomic, strong, readonly) AndBodyMethod withBody;
-@property (nonatomic, strong, readonly) AndReturnMethod andReturn;
-@property (nonatomic, strong, readonly) AndReturnRawResponseMethod andReturnRawResponse;
-@property (nonatomic, strong, readonly) AndFailWithErrorMethod andFailWithError;
+@property (nonatomic, strong, readonly) _Nonnull WithHeaderMethod withHeader;
+@property (nonatomic, strong, readonly) _Nonnull WithHeadersMethod withHeaders;
+@property (nonatomic, strong, readonly) _Nonnull AndBodyMethod withBody;
+@property (nonatomic, strong, readonly) _Nonnull AndReturnMethod andReturn;
+@property (nonatomic, strong, readonly) _Nonnull AndReturnRawResponseMethod andReturnRawResponse;
+@property (nonatomic, strong, readonly) _Nonnull AndFailWithErrorMethod andFailWithError;
 
 @end
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url);
-    
+
+LSStubRequestDSL * _Nonnull stubRequest(NSString * _Nonnull method, _Nonnull id<LSMatcheable> url);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Nocilla/DSL/LSStubResponseDSL.h
+++ b/Nocilla/DSL/LSStubResponseDSL.h
@@ -5,15 +5,15 @@
 
 @protocol LSHTTPBody;
 
-typedef LSStubResponseDSL *(^ResponseWithBodyMethod)(id<LSHTTPBody>);
-typedef LSStubResponseDSL *(^ResponseWithHeaderMethod)(NSString *, NSString *);
-typedef LSStubResponseDSL *(^ResponseWithHeadersMethod)(NSDictionary *);
+typedef LSStubResponseDSL * _Nonnull (^ResponseWithBodyMethod)(_Nullable id<LSHTTPBody>);
+typedef LSStubResponseDSL * _Nonnull (^ResponseWithHeaderMethod)(NSString * _Nonnull, NSString * _Nullable);
+typedef LSStubResponseDSL * _Nonnull (^ResponseWithHeadersMethod)(NSDictionary * _Nonnull);
 
 @interface LSStubResponseDSL : NSObject
-- (id)initWithResponse:(LSStubResponse *)response;
+- (id _Nonnull)initWithResponse:(LSStubResponse * _Nonnull)response;
 
-@property (nonatomic, strong, readonly) ResponseWithHeaderMethod withHeader;
-@property (nonatomic, strong, readonly) ResponseWithHeadersMethod withHeaders;
-@property (nonatomic, strong, readonly) ResponseWithBodyMethod withBody;
+@property (nonatomic, strong, readonly) _Nonnull ResponseWithHeaderMethod withHeader;
+@property (nonatomic, strong, readonly) _Nonnull ResponseWithHeadersMethod withHeaders;
+@property (nonatomic, strong, readonly) _Nonnull ResponseWithBodyMethod withBody;
 
 @end


### PR DESCRIPTION
This adds annotations necessary for normal usage on Swift 3. Without these, code must deal with null values that Nocilla never actually returns, i.e. lots of `?` interspersed in Nocilla DSL calls.

I haven’t been able to find an Obj-C annotation that gets rid of unused value warnings for the returned function pointers Nocilla uses. In Swift 3, it’s necessary to do this:

```
_ = stubRequest(...)
```
