### PR TITLE
Added `andReturnWithStatusCode` for a clearer name and enabled having both OCMock and Nocilla in 1 project

### DIFF
--- a/Nocilla/DSL/LSStubRequestDSL.h
+++ b/Nocilla/DSL/LSStubRequestDSL.h
@@ -23,6 +23,7 @@ typedef void (^AndFailWithErrorMethod)(NSError *error);
 @property (nonatomic, strong, readonly) WithHeadersMethod withHeaders;
 @property (nonatomic, strong, readonly) AndBodyMethod withBody;
 @property (nonatomic, strong, readonly) AndReturnMethod andReturn;
+@property (nonatomic, strong, readonly) AndReturnMethod andReturnWithStatusCode;
 @property (nonatomic, strong, readonly) AndReturnRawResponseMethod andReturnRawResponse;
 @property (nonatomic, strong, readonly) AndFailWithErrorMethod andFailWithError;
 

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -48,6 +48,10 @@
     };
 }
 
+- (AndReturnMethod)andReturnWithStatusCode {
+  return self.andReturn;
+}
+
 - (AndReturnRawResponseMethod)andReturnRawResponse {
     return ^(NSData *rawResponseData) {
         self.request.response = [[LSStubResponse alloc] initWithRawResponse:rawResponseData];


### PR DESCRIPTION
Avoid conflicts with https://github.com/erikdoe/ocmock/blob/5d9028ff40fe2bbe0ddc710b423cfc78fd5a006c/Source/OCMock/OCMStubRecorder.h#L23