### PR TITLE
Added NSURLMatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: objective-c
+osx_image: xcode8
+rvm: 1.9.3
 
 before_install:
-    - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-    - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
+    - gem install cocoapods -v '0.32.1' --no-rdoc --no-ri --no-document --quiet
 
 install:
     - pod repo remove master
@@ -11,4 +12,4 @@ install:
     - pod install
 
 script:
-    - set -o pipefail && xcodebuild -workspace Nocilla.xcworkspace -scheme 'Nocilla' -sdk iphonesimulator build test CODE_SIGN_IDENTITY=- | xcpretty -c
+    - set -o pipefail && xcodebuild -workspace Nocilla.xcworkspace -scheme 'Nocilla' -sdk iphonesimulator build test CODE_SIGN_IDENTITY=-

--- a/Nocilla.podspec
+++ b/Nocilla.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/luisobo/Nocilla.git", :tag => "0.11.0" }
 
-  s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Nocilla/**/*.{h,m}'

--- a/Nocilla.xcodeproj/project.pbxproj
+++ b/Nocilla.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		012091811E2CF4A9008B0520 /* NSURL+Matcheable.h in Headers */ = {isa = PBXBuildFile; fileRef = 0120917F1E2CF4A9008B0520 /* NSURL+Matcheable.h */; };
+		012091821E2CF4A9008B0520 /* NSURL+Matcheable.m in Sources */ = {isa = PBXBuildFile; fileRef = 012091801E2CF4A9008B0520 /* NSURL+Matcheable.m */; };
+		012091851E2CF502008B0520 /* LSURLMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 012091831E2CF502008B0520 /* LSURLMatcher.h */; };
+		012091861E2CF502008B0520 /* LSURLMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 012091841E2CF502008B0520 /* LSURLMatcher.m */; };
+		012091881E2CF97B008B0520 /* LSURLMatcherSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 012091871E2CF97B008B0520 /* LSURLMatcherSpec.m */; };
 		0FA3E7FE1680775B001DB582 /* LSStubResponseSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3E7FD1680775B001DB582 /* LSStubResponseSpec.m */; };
 		54540B881AC426490042C146 /* Nocilla.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5475C73D1AC4252400EB9514 /* Nocilla.framework */; };
 		5460AD241AD4052C00681BF9 /* Nocilla.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5475C73D1AC4252400EB9514 /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -222,6 +227,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0120917F1E2CF4A9008B0520 /* NSURL+Matcheable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+Matcheable.h"; path = "Matchers/NSURL+Matcheable.h"; sourceTree = "<group>"; };
+		012091801E2CF4A9008B0520 /* NSURL+Matcheable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURL+Matcheable.m"; path = "Matchers/NSURL+Matcheable.m"; sourceTree = "<group>"; };
+		012091831E2CF502008B0520 /* LSURLMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSURLMatcher.h; path = Matchers/LSURLMatcher.h; sourceTree = "<group>"; };
+		012091841E2CF502008B0520 /* LSURLMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSURLMatcher.m; path = Matchers/LSURLMatcher.m; sourceTree = "<group>"; };
+		012091871E2CF97B008B0520 /* LSURLMatcherSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSURLMatcherSpec.m; path = Matchers/LSURLMatcherSpec.m; sourceTree = "<group>"; };
 		09F886D44E0926E9B288752D /* libPods-NocillaTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NocillaTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FA3E7FD1680775B001DB582 /* LSStubResponseSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LSStubResponseSpec.m; sourceTree = "<group>"; };
 		15E14959C852D96F22BB841E /* Pods-NocillaTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NocillaTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-NocillaTests/Pods-NocillaTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -626,6 +636,10 @@
 				A08A3B481A101BBB0009482F /* LSDataMatcher.m */,
 				A08A3B4B1A101DA20009482F /* NSData+Matcheable.h */,
 				A08A3B4C1A101DA20009482F /* NSData+Matcheable.m */,
+				012091831E2CF502008B0520 /* LSURLMatcher.h */,
+				012091841E2CF502008B0520 /* LSURLMatcher.m */,
+				0120917F1E2CF4A9008B0520 /* NSURL+Matcheable.h */,
+				012091801E2CF4A9008B0520 /* NSURL+Matcheable.m */,
 			);
 			name = Matchers;
 			sourceTree = "<group>";
@@ -635,6 +649,7 @@
 			children = (
 				E48784AB1AFD7678001B5F2D /* LSDataMatcherSpec.m */,
 				A08EE2231728A241001830E6 /* LSStringMatcherSpec.m */,
+				012091871E2CF97B008B0520 /* LSURLMatcherSpec.m */,
 				A02889421728CD6000288022 /* LSRegexMatcherSpec.m */,
 			);
 			name = Matchers;
@@ -668,6 +683,7 @@
 				5475C75C1AC4254600EB9514 /* LSMatcheable.h in Headers */,
 				5475C78C1AC4254600EB9514 /* LSNocilla.h in Headers */,
 				5475C7631AC4254600EB9514 /* NSRegularExpression+Matcheable.h in Headers */,
+				012091811E2CF4A9008B0520 /* NSURL+Matcheable.h in Headers */,
 				5475C76B1AC4254600EB9514 /* LSHTTPBody.h in Headers */,
 				5475C77B1AC4254600EB9514 /* LSASIHTTPRequestHook.h in Headers */,
 				5475C78B1AC4254600EB9514 /* Nocilla.h in Headers */,
@@ -681,6 +697,7 @@
 				5475C7691AC4254600EB9514 /* LSHTTPRequest.h in Headers */,
 				5475C7731AC4254600EB9514 /* LSStubRequestDSL.h in Headers */,
 				5475C77D1AC4254600EB9514 /* ASIHTTPRequestStub.h in Headers */,
+				012091851E2CF502008B0520 /* LSURLMatcher.h in Headers */,
 				5475C7561AC4254600EB9514 /* NSString+Nocilla.h in Headers */,
 				5475C77F1AC4254600EB9514 /* LSASIHTTPRequestAdapter.h in Headers */,
 				5475C75D1AC4254600EB9514 /* NSString+Matcheable.h in Headers */,
@@ -849,7 +866,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0600;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Luis Solano Bonet";
 				TargetAttributes = {
 					5475C73C1AC4252300EB9514 = {
@@ -955,7 +972,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -974,6 +991,7 @@
 				5475C76F1AC4254600EB9514 /* LSStubResponse.m in Sources */,
 				5475C7711AC4254600EB9514 /* LSHTTPRequestDiff.m in Sources */,
 				5475C7621AC4254600EB9514 /* LSRegexMatcher.m in Sources */,
+				012091861E2CF502008B0520 /* LSURLMatcher.m in Sources */,
 				5475C77A1AC4254600EB9514 /* LSNSURLSessionHook.m in Sources */,
 				5475C7821AC4254600EB9514 /* LSHTTPClientHook.m in Sources */,
 				5475C7681AC4254600EB9514 /* NSData+Matcheable.m in Sources */,
@@ -989,6 +1007,7 @@
 				5475C76D1AC4254600EB9514 /* LSStubRequest.m in Sources */,
 				5475C7661AC4254600EB9514 /* LSDataMatcher.m in Sources */,
 				5475C7861AC4254600EB9514 /* LSNSURLHook.m in Sources */,
+				012091821E2CF4A9008B0520 /* NSURL+Matcheable.m in Sources */,
 				5475C77C1AC4254600EB9514 /* LSASIHTTPRequestHook.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -997,6 +1016,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				012091881E2CF97B008B0520 /* LSURLMatcherSpec.m in Sources */,
 				A02C7ACA15ECDD780061FCEE /* LSHTTPRequestDiffSpec.m in Sources */,
 				A02C7ADE15ED75480061FCEE /* LSHTTPRequestDSLRepresentationSpec.m in Sources */,
 				A0055EE415EEAE08005D6C85 /* MKNetworkKitStubbingSpec.m in Sources */,
@@ -1116,7 +1136,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1159,7 +1179,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1193,11 +1213,21 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1205,10 +1235,14 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -1220,14 +1254,28 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1273,6 +1321,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1319,6 +1368,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla Mac.xcscheme
+++ b/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla tvOS.xcscheme
+++ b/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla.xcscheme
+++ b/Nocilla.xcodeproj/xcshareddata/xcschemes/Nocilla.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nocilla/DSL/LSStubRequestDSL.m
+++ b/Nocilla/DSL/LSStubRequestDSL.m
@@ -2,6 +2,7 @@
 #import "LSStubResponseDSL.h"
 #import "LSStubRequest.h"
 #import "LSNocilla.h"
+#import "NSURL+Matcheable.h"
 
 @interface LSStubRequestDSL ()
 @property (nonatomic, strong) LSStubRequest *request;
@@ -65,7 +66,11 @@
 @end
 
 LSStubRequestDSL * stubRequest(NSString *method, id<LSMatcheable> url) {
-    LSStubRequest *request = [[LSStubRequest alloc] initWithMethod:method urlMatcher:url.matcher];
+    LSMatcher *matcheable = url.matcher;
+    if ([url isKindOfClass:[NSString class]]) {
+        matcheable = [NSURL URLWithString:(NSString *)url].matcher;
+    }
+    LSStubRequest *request = [[LSStubRequest alloc] initWithMethod:method urlMatcher:matcheable];
     LSStubRequestDSL *dsl = [[LSStubRequestDSL alloc] initWithRequest:request];
     [[LSNocilla sharedInstance] addStubbedRequest:request];
     return dsl;

--- a/Nocilla/Matchers/LSURLMatcher.h
+++ b/Nocilla/Matchers/LSURLMatcher.h
@@ -1,0 +1,18 @@
+//
+//  LSURLMatcher.h
+//  Nocilla
+//
+//  Created by Nick Lockwood on 16/01/2017.
+//  Copyright © 2017 Luis Solano Bonet. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "LSMatcher.h"
+
+@interface LSURLMatcher : LSMatcher
+
+- (instancetype)initWithURL:(NSURL *)url;
+
+- (instancetype)initWithString:(NSString *)urlString;
+
+@end

--- a/Nocilla/Matchers/LSURLMatcher.m
+++ b/Nocilla/Matchers/LSURLMatcher.m
@@ -1,0 +1,74 @@
+//
+//  LSURLMatcher.m
+//  Nocilla
+//
+//  Created by Nick Lockwood on 16/01/2017.
+//  Copyright © 2017 Luis Solano Bonet. All rights reserved.
+//
+
+#import "LSURLMatcher.h"
+
+@interface LSURLMatcher ()
+
+@property (nonatomic, copy) NSURL *url;
+
+@end
+
+@implementation LSURLMatcher
+
+- (instancetype)initWithURL:(NSURL *)url {
+    self = [super init];
+
+    if (self) {
+        _url = url;
+    }
+    return self;
+}
+
+- (instancetype)initWithString:(NSString *)urlString {
+    return [self initWithURL:[NSURL URLWithString:urlString]];
+}
+
+- (BOOL)matchesURL:(NSURL *)otherURL {
+    // Sort the query items alphabetically
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self.url resolvingAgainstBaseURL:YES];
+    components.queryItems = [components.queryItems sortedArrayUsingComparator:^NSComparisonResult(NSURLQueryItem *a, NSURLQueryItem *b) {
+        return [a.name compare:b.name];
+    }];
+    NSURLComponents *otherComponents = [NSURLComponents componentsWithURL:otherURL resolvingAgainstBaseURL:YES];
+    otherComponents.queryItems = [otherComponents.queryItems sortedArrayUsingComparator:^NSComparisonResult(NSURLQueryItem *a, NSURLQueryItem *b) {
+        return [a.name compare:b.name];
+    }];
+    // Compare normalized copies of the URLs
+    return [components.string isEqualToString:otherComponents.string];
+}
+
+
+- (BOOL)matches:(NSString *)string {
+    NSURL *url = [NSURL URLWithString:string];
+    if (url == nil) {
+        return self.url == nil;
+    }
+    return [self matchesURL:url];
+}
+
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[LSURLMatcher class]]) {
+        return NO;
+    }
+
+    return [self.url isEqual:((LSURLMatcher *)object).url];
+}
+
+- (NSUInteger)hash {
+    return self.url.hash;
+}
+
+@end

--- a/Nocilla/Matchers/NSURL+Matcheable.h
+++ b/Nocilla/Matchers/NSURL+Matcheable.h
@@ -1,0 +1,14 @@
+//
+//  NSURL+Matcheable.h
+//  Nocilla
+//
+//  Created by Nick Lockwood on 16/01/2017.
+//  Copyright © 2017 Luis Solano Bonet. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "LSMatcheable.h"
+
+@interface NSURL (Matcheable) <LSMatcheable>
+
+@end

--- a/Nocilla/Matchers/NSURL+Matcheable.m
+++ b/Nocilla/Matchers/NSURL+Matcheable.m
@@ -1,0 +1,18 @@
+//
+//  NSURL+Matcheable.m
+//  Nocilla
+//
+//  Created by Nick Lockwood on 16/01/2017.
+//  Copyright © 2017 Luis Solano Bonet. All rights reserved.
+//
+
+#import "NSURL+Matcheable.h"
+#import "LSURLMatcher.h"
+
+@implementation NSURL (Matcheable)
+
+- (LSMatcher *)matcher {
+    return [[LSURLMatcher alloc] initWithURL:self];
+}
+
+@end

--- a/Nocilla/Stubs/LSStubRequest.m
+++ b/Nocilla/Stubs/LSStubRequest.m
@@ -1,6 +1,6 @@
 #import "LSStubRequest.h"
 #import "LSMatcher.h"
-#import "NSString+Matcheable.h"
+#import "NSURL+Matcheable.h"
 
 @interface LSStubRequest ()
 @property (nonatomic, strong, readwrite) NSString *method;
@@ -16,7 +16,7 @@
 @implementation LSStubRequest
 
 - (instancetype)initWithMethod:(NSString *)method url:(NSString *)url {
-    return [self initWithMethod:method urlMatcher:[url matcher]];
+    return [self initWithMethod:method urlMatcher:[[NSURL URLWithString:url] matcher]];
 }
 
 - (instancetype)initWithMethod:(NSString *)method urlMatcher:(LSMatcher *)urlMatcher; {

--- a/NocillaTests/Matchers/LSURLMatcherSpec.m
+++ b/NocillaTests/Matchers/LSURLMatcherSpec.m
@@ -1,0 +1,52 @@
+#import "Kiwi.h"
+#import "LSURLMatcher.h"
+
+SPEC_BEGIN(LSURLMatcherSpec)
+
+__block LSURLMatcher *matcher = nil;
+beforeEach(^{
+    matcher = [[LSURLMatcher alloc] initWithString:@"http://example.com?foo=bar&bar=foo"];
+});
+
+context(@"when both strings are equal", ^{
+    it(@"matches", ^{
+        [[theValue([matcher matches:@"http://example.com?foo=bar&bar=foo"]) should] beYes];
+    });
+});
+
+context(@"when both strings are equivalent", ^{
+    it(@"matches", ^{
+        [[theValue([matcher matches:@"http://example.com?bar=foo&foo=bar"]) should] beYes];
+    });
+});
+
+context(@"when both strings are different", ^{
+    it(@"does not match", ^{
+        [[theValue([matcher matches:@"http://example.com?foo=bar&bar=baz"]) should] beNo];
+    });
+});
+
+describe(@"isEqual:", ^{
+    it(@"is equal to another string matcher with the same string", ^{
+        LSURLMatcher *matcherA = [[LSURLMatcher alloc] initWithString:@"http://example.com"];
+        LSURLMatcher *matcherB = [[LSURLMatcher alloc] initWithString:@"http://example.com"];
+
+        [[matcherA should] equal:matcherB];
+    });
+
+    it(@"is not equal to another string matcher with a different string", ^{
+        LSURLMatcher *matcherA = [[LSURLMatcher alloc] initWithString:@"http://example.com?foo=bar"];
+        LSURLMatcher *matcherB = [[LSURLMatcher alloc] initWithString:@"http://example.com?bar=foo"];
+
+        [[matcherA shouldNot] equal:matcherB];
+    });
+
+    it(@"is not equal to another string matcher with an equivalent string", ^{
+        LSURLMatcher *matcherA = [[LSURLMatcher alloc] initWithString:@"http://example.com?foo=bar&bar=foo"];
+        LSURLMatcher *matcherB = [[LSURLMatcher alloc] initWithString:@"http://example.com?bar=foo&foo=bar"];
+
+        [[matcherA shouldNot] equal:matcherB];
+    });
+});
+
+SPEC_END

--- a/NocillaTests/Stubs/LSStubRequestSpec.m
+++ b/NocillaTests/Stubs/LSStubRequestSpec.m
@@ -18,6 +18,15 @@ describe(@"#matchesRequest:", ^{
             [[theValue([stubRequest matchesRequest:other]) should] beYes];
         });
     });
+    context(@"when the methods are equal and the URLs are equivalent", ^{
+        it(@"should match", ^{
+            LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json?foo=bar&bar=foo"];
+
+            LSTestRequest *other = [[LSTestRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json?bar=foo&foo=bar"];
+
+            [[theValue([stubRequest matchesRequest:other]) should] beYes];
+        });
+    });
     context(@"when the method is different", ^{
         it(@"should not match", ^{
             LSStubRequest *stubRequest = [[LSStubRequest alloc] initWithMethod:@"PUT" url:@"https://api.example.com/cats/whiskas.json"];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,18 +20,18 @@ PODS:
   - AFNetworking/UIKit (2.4.1):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - ASIHTTPRequest (1.8.1):
-    - ASIHTTPRequest/ASIWebPageRequest (= 1.8.1)
-    - ASIHTTPRequest/CloudFiles (= 1.8.1)
-    - ASIHTTPRequest/Core (= 1.8.1)
-    - ASIHTTPRequest/S3 (= 1.8.1)
-  - ASIHTTPRequest/ASIWebPageRequest (1.8.1):
+  - ASIHTTPRequest (1.8.2):
+    - ASIHTTPRequest/ASIWebPageRequest (= 1.8.2)
+    - ASIHTTPRequest/CloudFiles (= 1.8.2)
+    - ASIHTTPRequest/Core (= 1.8.2)
+    - ASIHTTPRequest/S3 (= 1.8.2)
+  - ASIHTTPRequest/ASIWebPageRequest (1.8.2):
     - ASIHTTPRequest/Core
-  - ASIHTTPRequest/CloudFiles (1.8.1):
+  - ASIHTTPRequest/CloudFiles (1.8.2):
     - ASIHTTPRequest/Core
-  - ASIHTTPRequest/Core (1.8.1):
+  - ASIHTTPRequest/Core (1.8.2):
     - Reachability
-  - ASIHTTPRequest/S3 (1.8.1):
+  - ASIHTTPRequest/S3 (1.8.2):
     - ASIHTTPRequest/Core
   - CocoaAsyncSocket (0.0.1)
   - CocoaHTTPServer (2.2.1):
@@ -52,7 +52,7 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   AFNetworking: 41d45d2c14219af0fa5addf3cfd433a002c13c9f
-  ASIHTTPRequest: bf4f9b8be3526d40865d045bb664e0bab246fb81
+  ASIHTTPRequest: ec013992946676b7978dcbde6396d57312d21db4
   CocoaAsyncSocket: e2688ff99f2c2dbbeb95a1d02ba7dd878726ac83
   CocoaHTTPServer: 36f27f3fbc03d25a4fafcc22409a944c5bcf0d2d
   CocoaLumberjack: 9c1e36cb5bf886ad691191f59871a11179c7c2aa
@@ -62,4 +62,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6845bdf1d8a193a8186fdae487e0615d7037f7ba
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.1.1


### PR DESCRIPTION
This PR Adds an LSURLMatcher class, and updates LSStubRequest to use it instead of the regular LSStringMatcher.

The motivation for this is that LSStringMatcher is not content aware, and so creates false negatives when matching URLs that are equivalent but not identical. The most common example is when the query parameter order is different, e.g:

    http://example.com?foo=bar&bar=foo
    http://example.com?bar=foo&foo=bar

Query parameter order can be non-deterministic, as it depends on things like the order of enumeration of an NSDictionary, which is undocumented, and changes between iOS versions, or when using different enumeration methods.