### PR TITLE
Early returning in -[LSHTTPStubURLProtocol startLoading] to prevent failures

### DIFF
--- a/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
+++ b/Nocilla/Hooks/NSURLRequest/LSHTTPStubURLProtocol.m
@@ -18,8 +18,12 @@
 }
 
 - (void)startLoading {
+    if (![LSNocilla sharedInstance].started) {
+        // Nocilla was stopped, but some request went through, let's not fail possibly other tests
+        return;
+    }
     NSURLRequest* request = [self request];
-	id<NSURLProtocolClient> client = [self client];
+    id<NSURLProtocolClient> client = [self client];
 
     LSStubResponse* stubbedResponse = [[LSNocilla sharedInstance] responseForRequest:request];
 


### PR DESCRIPTION
Since `NSURLSession` will execute the requests on a background thread, we can end up in the situation when the `tearDown` of a previous unit test stops Nocilla since it no longer needs it, and `startLoading` gets called while in the middle of another unrelated test case, thus causing an exception and failing the other test.

So, we're early returning from `startLoading` to prevent this kind of failures.